### PR TITLE
프로필 이미지 업로드 및 헤더 아바타 연동

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { User, Settings, LogOut, BarChart3, Menu, X, UserCircle, Clock, Warehouse, Dumbbell } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
@@ -64,6 +64,7 @@ export const Header = () => {
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" className="relative h-8 w-8 rounded-full">
                     <Avatar className="h-9 w-9">
+                      <AvatarImage src={member?.profileUrl} alt={member?.nickname} />
                       <AvatarFallback>
                         {member?.nickname?.slice(0,2)?.toUpperCase() || 'U'}
                       </AvatarFallback>
@@ -135,6 +136,7 @@ export const Header = () => {
             {/* 사용자 정보 */}
             <div className="flex items-center space-x-3 pb-3 border-b">
               <Avatar className="h-10 w-10">
+                <AvatarImage src={member?.profileUrl} alt={member?.nickname} />
                 <AvatarFallback>
                   {member?.nickname?.slice(0,2)?.toUpperCase() || 'U'}
                 </AvatarFallback>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -408,6 +408,12 @@ class ApiClient {
     return await this.request("/members/profile", { method: "PUT", data: profileData });
   }
 
+  async uploadProfileImage(file: File): Promise<{ profileUrl: string }> {
+    const formData = new FormData();
+    formData.append("image", file);
+    return this.uploadFile<{ profileUrl: string }>("/members/profile/image", formData);
+  }
+
   async getUserWorkoutFeed(page: number = 0, size: number = 20) {
       return await this.request(`/members/workout-feed?page=${page}&size=${size}`);
   }


### PR DESCRIPTION
Closes #38

## Description
- API: `uploadProfileImage` 추가 (`POST /members/profile/image`)
- UserProfileSection: 아바타 클릭 시 프로필 이미지 업로드 (JPEG/PNG/WebP, 5MB 제한), 로딩/호버 UI 및 접근성 처리
- Header: 아바타에 `AvatarImage`로 `member.profileUrl` 표시하여 프로필 변경 시 즉시 반영