### PR TITLE
운동 업로드 성공 다이얼로그 자동 이동 카운트다운 개선

### DIFF
--- a/src/components/WorkoutSuccessDialog.tsx
+++ b/src/components/WorkoutSuccessDialog.tsx
@@ -11,6 +11,7 @@ interface WorkoutSuccessDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   totalWorkoutDays: number;
+  redirectSeconds: number;
   // onNavigate: () => void;
 }
 
@@ -18,6 +19,7 @@ export const WorkoutSuccessDialog = ({
   open,
   onOpenChange,
   totalWorkoutDays,
+  redirectSeconds,
   // onNavigate,
 }: WorkoutSuccessDialogProps) => {
   const getWorkoutMessage = (totalWorkoutDays: number) => {
@@ -91,7 +93,7 @@ export const WorkoutSuccessDialog = ({
               {workoutMessageInfo.emoji} {workoutMessageInfo.message}
             </div>            
             <div className="text-xs text-gray-400">
-              5초 후 자동으로 대시보드로 이동합니다.
+              {redirectSeconds}초 후 자동으로 대시보드로 이동합니다.
             </div>
           </DialogDescription>
         </DialogHeader>

--- a/src/pages/WorkoutUploadPage.tsx
+++ b/src/pages/WorkoutUploadPage.tsx
@@ -24,6 +24,7 @@ const toDateOnly = (date) => {
 }
 const today = toDateOnly(new Date());
 const sevenDaysAgo = toDateOnly(new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000));
+const REDIRECT_DELAY_SECONDS = 3;
 
 export const WorkoutUploadPage = () => {
   const { member } = useAuth();
@@ -44,6 +45,7 @@ export const WorkoutUploadPage = () => {
   const [totalWorkoutDays, setTotalWorkoutDays] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
   const [workoutRoomId, setWorkoutRoomId] = useState<number | null>(null);
+  const [redirectCountdown, setRedirectCountdown] = useState(REDIRECT_DELAY_SECONDS);
 
   const processFiles = async (files: FileList | File[]) => {
     const fileArray = Array.from(files);
@@ -239,14 +241,23 @@ export const WorkoutUploadPage = () => {
     }
   }, [currentWorkoutRoom]);  
 
-  // 성공 다이얼로그 표시 5초 후 자동으로 대시보드로 이동
+  // 성공 다이얼로그 표시 후 일정 시간 뒤 대시보드로 이동 + 카운트다운
   useEffect(() => {
     if (showSuccessDialog) {
-      const timer = setTimeout(() => {
-        navigate('/dashboard');
-      }, 5000);
+      setRedirectCountdown(REDIRECT_DELAY_SECONDS);
 
-      return () => clearTimeout(timer);
+      const countdownInterval = setInterval(() => {
+        setRedirectCountdown((prev) => Math.max(prev - 1, 1));
+      }, 1000);
+
+      const navigateTimeout = setTimeout(() => {
+        navigate('/dashboard');
+      }, REDIRECT_DELAY_SECONDS * 1000);
+
+      return () => {
+        clearInterval(countdownInterval);
+        clearTimeout(navigateTimeout);
+      };
     }
   }, [showSuccessDialog, navigate]);
 
@@ -257,6 +268,7 @@ export const WorkoutUploadPage = () => {
           open={showSuccessDialog}
           onOpenChange={setShowSuccessDialog}
           totalWorkoutDays={totalWorkoutDays}
+          redirectSeconds={redirectCountdown}
         />
         <Card>
           <CardHeader>


### PR DESCRIPTION
Closes #56

## Description
운동 업로드 성공 다이얼로그에서 대시보드 자동 이동 UX를 개선했습니다.

- `WorkoutSuccessDialog`에 `redirectSeconds` props를 추가하고, 안내 문구에서 이 값을 사용해 남은 초를 동적으로 표시
- `WorkoutUploadPage`에서 성공 다이얼로그가 열릴 때 3초 카운트다운과 함께 대시보드로 자동 이동하도록 구현
- `REDIRECT_DELAY_SECONDS = 3` 상수 기반으로 `redirectCountdown` 상태를 업데이트하며, 인터벌/타임아웃 클리어로 타이머 누수 및 중복 네비게이션을 방지

## Test Plan
- 운동 업로드 성공 시 다이얼로그에 "3초 후 자동으로 대시보드로 이동합니다."가 보이고, 3 → 2 → 1로 카운트다운되는지 확인
- 3초 뒤 자동으로 `/dashboard`로 이동하는지 확인
- 업로드 성공 후 다이얼로그를 빠르게 닫을 때, 추가로 자동 이동이 발생하지 않는지 확인