### PR TITLE
운동 업로드 응답 타입 적용 및 누적 운동일 서버 값 사용

### DIFF
--- a/src/pages/WorkoutUploadPage.tsx
+++ b/src/pages/WorkoutUploadPage.tsx
@@ -12,7 +12,7 @@ import { WorkoutSuccessDialog } from '@/components/WorkoutSuccessDialog';
 import { useAuth } from '@/contexts/AuthContext';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
-import { WORKOUT_TYPES, WorkoutType } from '@/types';
+import { WORKOUT_TYPES, WorkoutResponse, WorkoutType } from '@/types';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { CalendarIcon, Loader2, Upload, X } from 'lucide-react';
@@ -197,13 +197,13 @@ export const WorkoutUploadPage = () => {
         duration: parseInt(duration)
       };
 
-      await api.uploadWorkout(workoutData, selectedImages);
+      const data = await api.uploadWorkout(workoutData, selectedImages) as WorkoutResponse;
 
       // 날짜가 오늘인지 확인 (타임스탬프 비교)
       const isTodayParams = today.getTime() === toDateOnly(workoutDate).getTime();
 
       // 날짜에 따라 메시지 분기 처리
-      const dateText = isTodayParams ? "오늘" : format(workoutDate, 'yyyy-MM-dd'); 
+      const dateText = isTodayParams ? "오늘" : format(workoutDate, 'yyyy-MM-dd');
 
       if (member.role == 'ADMIN') {
         api.notifyRoomMembersForAdmin({
@@ -223,7 +223,7 @@ export const WorkoutUploadPage = () => {
           console.warn('운동 업로드 알림 전송 실패', notifyErr);
         });
       }
-      setTotalWorkoutDays(member.totalWorkoutDays + 1);
+      setTotalWorkoutDays(data.memberTotalWorkoutDays);
       // 성공 다이얼로그 표시
       setShowSuccessDialog(true);
     } catch (err) {
@@ -236,7 +236,6 @@ export const WorkoutUploadPage = () => {
 
   useEffect(() => {
     if (currentWorkoutRoom) {
-      console.log("전달받은 방 정보:", currentWorkoutRoom);
       setWorkoutRoomId(currentWorkoutRoom.workoutRoomInfo.id);
     }
   }, [currentWorkoutRoom]);  

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,14 @@ export interface WorkoutRecord {
   createdAt: string;
 }
 
+export interface WorkoutResponse {
+  workoutDate: string;
+  workoutTypes: string[]; // 여러 운동 종류 (서버에서 항상 배열로 반환)
+  duration: number; // minutes
+  imageUrls: string[]; // 여러 이미지 URL (서버에서 항상 배열로 반환)
+  memberTotalWorkoutDays: number;
+}
+
 export const WORKOUT_TYPES = [
   '헬스(가슴)', 
   '헬스(등)', 


### PR DESCRIPTION
Closes #59

## Description
- **WorkoutResponse** 타입 추가 및 업로드 API 응답에 적용
- 성공 다이얼로그의 총 운동일 수를 서버 응답 `memberTotalWorkoutDays` 기준으로 표시 (클라이언트 추정 제거)
- 디버그용 console.log 제거 및 코드 정리