### PR TITLE
대시보드 내 활동 카드 UI 및 텍스트 개선

### DIFF
--- a/src/components/dashboard/MyActivityCard.tsx
+++ b/src/components/dashboard/MyActivityCard.tsx
@@ -23,48 +23,55 @@ export const MyActivityCard = ({
         <CardTitle className="text-xl font-bold">내 활동</CardTitle>
       </CardHeader>
       <CardContent>
-        {todayWorkoutRecord ? (
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 bg-green-50 rounded-lg">
-            <div className="flex items-center gap-3 flex-1 min-w-0">
-              <div className="w-12 h-12 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0">
-                <Dumbbell className="h-6 w-6 text-white" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <p className="font-medium mb-1.5 sm:mb-1">오늘 운동 완료!</p>
-                <div className="flex flex-wrap items-center gap-1.5 mb-1.5 sm:mb-1">
-                  {todayWorkoutRecord.workoutTypes?.map((type, index) => (
-                    <Badge
-                      key={index}
-                      variant="secondary"
-                      className="bg-blue-100 text-blue-800 text-xs px-2 py-0.5"
-                    >
-                      {type}
-                    </Badge>
-                  ))}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-4 rounded-lg bg-gray-50">
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            {todayWorkoutRecord ? (
+              <>
+                <div className="w-12 h-12 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0">
+                  <Dumbbell className="h-6 w-6 text-white" />
                 </div>
-                <p className="text-sm text-muted-foreground">운동시간: {todayWorkoutRecord.duration}분</p>
-              </div>
-            </div>
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium mb-1.5 sm:mb-1">오늘 운동 완료!</p>
+                  <div className="flex flex-wrap items-center gap-1.5 mb-1.5 sm:mb-1">
+                    {todayWorkoutRecord.workoutTypes?.map((type, index) => (
+                      <Badge
+                        key={index}
+                        variant="secondary"
+                        className="bg-blue-100 text-blue-800 text-xs px-2 py-0.5"
+                      >
+                        {type}
+                      </Badge>
+                    ))}
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    운동시간: {todayWorkoutRecord.duration}분
+                  </p>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="w-12 h-12 bg-gray-300 rounded-full flex items-center justify-center flex-shrink-0">
+                  <Camera className="h-6 w-6 text-gray-600" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium mb-1.5 sm:mb-1">오늘 운동 하셨나요?</p>
+                  <p className="text-sm text-muted-foreground">
+                    운동했으면 얼른 인증하세요!
+                  </p>
+                </div>
+              </>
+            )}
           </div>
-        ) : (
-          <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
-            <div className="flex items-center space-x-3">
-              <div className="w-12 h-12 bg-gray-300 rounded-full flex items-center justify-center">
-                <Camera className="h-6 w-6 text-gray-600" />
-              </div>
-              <div></div>
-            </div>
-            <div className="flex gap-2">
-              <Button className="px-3" onClick={onWorkoutUpload}>
-                인증하기
-              </Button>
-              <Button variant="outline" className="px-3" onClick={onRestRegister}>
-                <Pause className="w-4 h-4 mr-1" />
-                휴식
-              </Button>
-            </div>
+          <div className="flex gap-2 mt-3 sm:mt-0 sm:ml-4">
+            <Button className="px-3" onClick={onWorkoutUpload}>
+              인증하기
+            </Button>
+            <Button variant="outline" className="px-3" onClick={onRestRegister}>
+              <Pause className="w-4 h-4 mr-1" />
+              휴식
+            </Button>
           </div>
-        )}
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Closes #65

## Description
대시보드 페이지의 `MyActivityCard` 컴포넌트에서 오늘 운동 기록 상태에 따른 UI와 문구를 정리하고, Tailwind 기반 레이아웃을 개선했습니다.
- 운동 기록이 있는 경우: 운동 완료 상태, 운동 종류 배지, 운동 시간 정보를 일관된 레이아웃으로 표시
- 운동 기록이 없는 경우: 카메라 아이콘과 안내 문구로 인증 유도 강화
- 버튼 영역 레이아웃을 반응형으로 조정하여 다양한 화면 크기에서 자연스럽게 정렬되도록 개선

이 PR은 사용자에게 더 명확한 피드백과 자연스러운 인터랙션을 제공하기 위한 UI/UX 개선 작업입니다.