### PR TITLE
벌금 현황 기간 필터(연/월/주/기간 지정) 및 API 기간 쿼리 지원

### DIFF
--- a/docs/BACKEND_PENALTY_RECORDS_PERIOD.md
+++ b/docs/BACKEND_PENALTY_RECORDS_PERIOD.md
@@ -1,0 +1,95 @@
+## 벌금 내역 기간 필터 백엔드 작업 정리
+
+### 1. 개요
+
+- 운동방 **벌금 현황**에서 프론트가 **기간(연도별/월간/주간/기간 지정)** 을 선택해 조회할 수 있도록, 백엔드에서 **쿼리 파라미터 기반 기간 필터링**을 지원해야 합니다.
+- 프론트는 `GET /penalty/rooms/:roomId/records` 호출 시 **`startDate`, `endDate`** 쿼리 파라미터를 선택적으로 보내며, 두 값이 모두 있을 때만 서버에서 기간 필터를 적용합니다. 하나라도 없으면 **전체 레코드**를 반환합니다(기존 동작 유지).
+
+---
+
+### 2. 프론트엔드에서 사용하는 API 스펙
+
+- **요청 메서드**: `GET`
+- **엔드포인트**: `/penalty/rooms/:roomId/records` (기존과 동일)
+- **경로 파라미터**
+  - `roomId`: `number` — 운동방 ID
+- **쿼리 파라미터** (선택)
+  - `startDate`: `string` (yyyy-MM-dd) — 조회 기간 시작일
+  - `endDate`: `string` (yyyy-MM-dd) — 조회 기간 종료일
+
+#### 동작
+
+- **`startDate`, `endDate`가 둘 다 있는 경우**: 주 단위 벌금 레코드 중, **레코드의 주차 기간(`weekStartDate` ~ `weekEndDate`)이 [startDate, endDate]와 겹치는 것만** 반환합니다.
+- **하나라도 없거나 미전달인 경우**: 기존처럼 **해당 방의 벌금 레코드 전체**를 반환합니다(하위 호환).
+
+---
+
+### 3. 프론트 호출 형태
+
+- **옵션용 전체 조회** (연/월/주 드롭다운 옵션 채우기):
+  - `GET /penalty/rooms/{roomId}/records`  
+  - 쿼리 파라미터 없음 → 전체 레코드 반환 기대
+
+- **기간별 목록 조회** (선택한 기간에 해당하는 레코드만):
+  - 연도별: `GET /penalty/rooms/{roomId}/records?startDate=2024-01-01&endDate=2024-12-31`
+  - 월간: `GET /penalty/rooms/{roomId}/records?startDate=2024-03-01&endDate=2024-03-31`
+  - 주간: `GET /penalty/rooms/{roomId}/records?startDate=2024-03-04&endDate=2024-03-10` (해당 주 월~일)
+  - 기간 지정: `GET /penalty/rooms/{roomId}/records?startDate=2024-02-01&endDate=2024-02-29` (사용자 선택값 그대로)
+
+---
+
+### 4. 필터 조건 (백엔드 구현 시)
+
+- 각 벌금 레코드는 **주 단위**로 `weekStartDate`, `weekEndDate`(ISO 문자열 또는 일자)를 가집니다.
+- **포함 조건**: 조회 구간 [startDate, endDate]와 **주차 구간이 하루라도 겹치는** 레코드만 반환합니다.
+  - 겹침 조건:  
+    `(레코드 weekStartDate의 일자 부분) <= endDate` **그리고**  
+    `(레코드 weekEndDate의 일자 부분) >= startDate`
+- 일자 비교 시 **날짜 문자열(yyyy-MM-dd) 비교** 또는 서버에서 사용하는 일자 타입으로 통일해 비교하면 됩니다.
+
+---
+
+### 5. 응답 스펙 (변경 없음)
+
+- 응답 타입: **벌금 레코드 배열** (기존과 동일).
+- 프론트에서 기대하는 항목: `id`, `workoutRoomMemberId`, `weekStartDate`, `weekEndDate`, `requiredWorkouts`, `actualWorkouts`, `penaltyAmount`, `isPaid`, `paidAt`(선택) 등 기존 `PenaltyRecord` 구조 유지.
+
+```json
+[
+  {
+    "id": 1,
+    "workoutRoomMemberId": "10",
+    "weekStartDate": "2024-03-04T00:00:00",
+    "weekEndDate": "2024-03-10T23:59:59",
+    "requiredWorkouts": 3,
+    "actualWorkouts": 2,
+    "penaltyAmount": 5000,
+    "isPaid": false,
+    "paidAt": null
+  }
+]
+```
+
+- 페이징은 적용하지 않으며, **해당 조건을 만족하는 레코드 전체**를 배열로 반환하면 됩니다.
+
+---
+
+### 6. 백엔드 구현 체크리스트
+
+- [ ] `GET /penalty/rooms/:roomId/records` 핸들러에서 쿼리 파라미터 `startDate`, `endDate` 수신
+- [ ] `startDate`, `endDate`가 **둘 다 존재할 때만** 기간 필터 적용
+- [ ] 필터 조건: `weekStartDate`(일자) ≤ `endDate` 이고 `weekEndDate`(일자) ≥ `startDate` 인 레코드만 조회
+- [ ] 하나라도 없으면 기존처럼 해당 방의 벌금 레코드 전체 반환
+- [ ] 응답 DTO/구조는 기존과 동일하게 유지
+
+---
+
+### 7. 참고 (프론트 로직)
+
+- 기간 타입별로 프론트가 계산해 보내는 값:
+  - **연도별**: `startDate = YYYY-01-01`, `endDate = YYYY-12-31`
+  - **월간**: 해당 월 1일 ~ 해당 월 마지막 날
+  - **주간**: 선택한 주의 `yyyy-MM-dd~yyyy-MM-dd` 문자열을 split한 start/end
+  - **기간 지정**: 사용자가 선택한 시작일/종료일 그대로
+
+백엔드는 **항상 `startDate`와 `endDate` 두 개만** 받아서 위 겹침 조건으로 필터링하면 됩니다.

--- a/src/components/PenaltyOverview.tsx
+++ b/src/components/PenaltyOverview.tsx
@@ -5,7 +5,6 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Badge } from '@/components/ui/badge';
 import { api } from '@/lib/api';
 import { formatDateToYmd, getTodayYmd } from '@/lib/workoutRoomRules';
 import { cn } from '@/lib/utils';
@@ -30,8 +29,10 @@ const getDefaultCustomRange = (): { start: string; end: string } => {
 };
 
 export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMembers, currentUserId }) => {
+  const [optionRecords, setOptionRecords] = useState<PenaltyRecord[]>([]);
   const [records, setRecords] = useState<PenaltyRecord[]>([]);
   const [paymentsMap, setPaymentsMap] = useState<Record<number, PenaltyPayment[]>>({});
+  const [isLoadingOptions, setIsLoadingOptions] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
 
   const [periodType, setPeriodType] = useState<PeriodType>('week');
@@ -42,14 +43,54 @@ export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMe
   const [customEndDate, setCustomEndDate] = useState<string>(() => getDefaultCustomRange().end);
   const [memberFilter, setMemberFilter] = useState<string>('ALL'); // ALL | ME | userId
 
+  // 서버에 넘길 기간: 선택에 따라 startDate/endDate 계산
+  const requestRange = useMemo((): { startDate: string; endDate: string } | null => {
+    if (periodType === 'year' && selectedYear) {
+      return { startDate: `${selectedYear}-01-01`, endDate: `${selectedYear}-12-31` };
+    }
+    if (periodType === 'month' && selectedYear && selectedMonth) {
+      const y = Number(selectedYear);
+      const m = Number(selectedMonth);
+      const lastDay = new Date(y, m, 0).getDate();
+      return {
+        startDate: `${selectedYear}-${selectedMonth}-01`,
+        endDate: `${selectedYear}-${selectedMonth}-${String(lastDay).padStart(2, '0')}`,
+      };
+    }
+    if (periodType === 'week' && selectedWeek) {
+      const [s, e] = selectedWeek.split('~');
+      if (s && e) return { startDate: s, endDate: e };
+    }
+    if (periodType === 'custom' && customStartDate && customEndDate) {
+      return { startDate: customStartDate, endDate: customEndDate };
+    }
+    return null;
+  }, [periodType, selectedYear, selectedMonth, selectedWeek, customStartDate, customEndDate]);
+
+  // 옵션용 전체 조회 (연/월/주 드롭다운용)
+  useEffect(() => {
+    const load = async () => {
+      setIsLoadingOptions(true);
+      try {
+        const recs = await api.getPenaltyRecords(roomId) as PenaltyRecord[];
+        setOptionRecords(recs);
+      } finally {
+        setIsLoadingOptions(false);
+      }
+    };
+    load();
+  }, [roomId]);
+
+  // 기간별 목록 조회 (서버에 startDate/endDate 전달)
   useEffect(() => {
     const load = async () => {
       setIsLoading(true);
       try {
-        const recs = await api.getPenaltyRecords(roomId) as PenaltyRecord[];
+        const recs = (requestRange
+          ? await api.getPenaltyRecords(roomId, requestRange)
+          : await api.getPenaltyRecords(roomId)) as PenaltyRecord[];
         setRecords(recs);
 
-        // Load payments for all records in parallel
         const entries: Array<[number, PenaltyPayment[]]> = await Promise.all(
           recs.map(async (r) => {
             try {
@@ -68,15 +109,15 @@ export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMe
       }
     };
     load();
-  }, [roomId]);
+  }, [roomId, requestRange]);
 
-  // 년/월/주 옵션 계산
+  // 년/월/주 옵션 계산 (optionRecords 기준)
   const { yearOptions, monthOptions, weekOptions } = useMemo(() => {
     const yearSet = new Set<string>();
     const monthSetByYear = new Map<string, Set<string>>();
     const weeksByYearMonth = new Map<string, Set<WeekKey>>();
 
-    for (const r of records) {
+    for (const r of optionRecords) {
       const start = new Date(r.weekStartDate);
       const y = String(start.getFullYear());
       const m = String(start.getMonth() + 1).padStart(2, '0');
@@ -102,7 +143,7 @@ export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMe
       : [];
 
     return { yearOptions: years, monthOptions: months, weekOptions: weeks };
-  }, [records, selectedYear, selectedMonth]);
+  }, [optionRecords, selectedYear, selectedMonth]);
 
   // 초기/연쇄 선택값 세팅
   useEffect(() => {
@@ -131,33 +172,14 @@ export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMe
     }
   }, [selectedYear, selectedMonth, weekOptions, selectedWeek]);
 
+  // 서버가 이미 기간으로 필터링한 records에 멤버 필터만 적용
   const filtered = useMemo(() => {
     return records.filter((r) => {
-      let byPeriod = true;
-      if (periodType === 'year') {
-        byPeriod = selectedYear ? r.weekStartDate.startsWith(selectedYear) : true;
-      } else if (periodType === 'month') {
-        const byYear = selectedYear ? r.weekStartDate.startsWith(selectedYear) : true;
-        const byMonth = selectedMonth ? r.weekStartDate.substring(5, 7) === selectedMonth : true;
-        byPeriod = byYear && byMonth;
-      } else if (periodType === 'week') {
-        const [s, e] = selectedWeek ? selectedWeek.split('~') : ['', ''];
-        const byYear = selectedYear ? r.weekStartDate.startsWith(selectedYear) : true;
-        const byMonth = selectedMonth ? r.weekStartDate.substring(5, 7) === selectedMonth : true;
-        const byWeek = selectedWeek ? r.weekStartDate.startsWith(s) && r.weekEndDate.startsWith(e) : true;
-        byPeriod = byYear && byMonth && byWeek;
-      } else {
-        // custom: 주 단위 기간이 사용자 지정 기간과 겹치는 레코드
-        const rStart = r.weekStartDate.substring(0, 10);
-        const rEnd = r.weekEndDate.substring(0, 10);
-        byPeriod = rStart <= customEndDate && rEnd >= customStartDate;
-      }
-      if (!byPeriod) return false;
       if (memberFilter === 'ALL') return true;
       if (memberFilter === 'ME') return String(r.workoutRoomMemberId) === String(currentUserId);
       return String(r.workoutRoomMemberId) === String(memberFilter);
     });
-  }, [records, periodType, selectedYear, selectedMonth, selectedWeek, customStartDate, customEndDate, memberFilter, currentUserId]);
+  }, [records, memberFilter, currentUserId]);
 
   const memberMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -176,6 +198,26 @@ export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMe
     const remain = Math.max(0, penalty - paid);
     return { penalty, paid, remain };
   }, [filtered, calcPaid]);
+
+  // 멤버별 그룹: workoutRoomMemberId 기준으로 묶고, 닉네임 순 정렬
+  const groupedByMember = useMemo(() => {
+    const map = new Map<string, PenaltyRecord[]>();
+    for (const r of filtered) {
+      const key = String(r.workoutRoomMemberId);
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(r);
+    }
+    const result: Array<{ memberId: string; nickname: string; records: PenaltyRecord[] }> = [];
+    for (const [memberId, recs] of map) {
+      const nickname = memberMap.get(memberId) ?? `회원 ${memberId}`;
+      const sorted = [...recs].sort(
+        (a, b) => new Date(b.weekStartDate).getTime() - new Date(a.weekStartDate).getTime()
+      );
+      result.push({ memberId, nickname, records: sorted });
+    }
+    result.sort((a, b) => a.nickname.localeCompare(b.nickname, 'ko'));
+    return result;
+  }, [filtered, memberMap]);
 
   const handleCustomStartSelect = (date: Date | undefined) => {
     if (!date) return;
@@ -280,7 +322,7 @@ export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMe
                     setSelectedWeek('');
                   }}
                 >
-                  <SelectTrigger className="w-full sm:w-36 h-10 text-sm" aria-label="연도 선택">
+                  <SelectTrigger className="w-full sm:w-36 h-10 text-sm" aria-label="연도 선택" disabled={isLoadingOptions}>
                     <SelectValue placeholder="연도" />
                   </SelectTrigger>
                   <SelectContent>
@@ -292,7 +334,7 @@ export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMe
 
                 {(periodType === 'month' || periodType === 'week') && (
                   <Select value={selectedMonth} onValueChange={(v) => { setSelectedMonth(v); setSelectedWeek(''); }}>
-                    <SelectTrigger className="w-full sm:w-32 h-10 text-sm" aria-label="월 선택">
+                    <SelectTrigger className="w-full sm:w-32 h-10 text-sm" aria-label="월 선택" disabled={isLoadingOptions}>
                       <SelectValue placeholder="월" />
                     </SelectTrigger>
                     <SelectContent>
@@ -343,57 +385,56 @@ export const PenaltyOverview: React.FC<PenaltyOverviewProps> = ({ roomId, roomMe
             <div className="h-20 bg-gray-100 rounded animate-pulse" />
             <div className="h-20 bg-gray-100 rounded animate-pulse" />
           </div>
-        ) : filtered.length === 0 ? (
+        ) : groupedByMember.length === 0 ? (
           <div className="text-center py-8 text-gray-500">벌금 내역이 없습니다.</div>
         ) : (
-          <div className="space-y-2 sm:space-y-3">
-            {filtered
-              .sort((a, b) => Number(a.workoutRoomMemberId) - Number(b.workoutRoomMemberId))
-              .map(r => {
-                const paid = calcPaid(r.id);
-                const remain = Math.max(0, r.penaltyAmount - paid);
-                const nickname = memberMap.get(String(r.workoutRoomMemberId)) || `회원 ${r.workoutRoomMemberId}`;
-                const status: { text: string; variant: 'default' | 'secondary' | 'destructive' } =
-                  r.penaltyAmount === 0
-                    ? { text: '벌금 없음', variant: 'secondary' }
-                    : paid >= r.penaltyAmount
-                    ? { text: '납부완료', variant: 'default' }
-                    : paid > 0
-                    ? { text: '부분납부', variant: 'secondary' }
-                    : { text: '미납부', variant: 'destructive' };
-
-                return (
-                  <button key={r.id} className="w-full text-left border rounded-lg p-3 sm:p-4 active:opacity-90">
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="space-y-0.5 sm:space-y-1">
-                        <div className="font-medium text-sm sm:text-base truncate max-w-[70vw] sm:max-w-none">{nickname}</div>
-                        <div className="text-xs sm:text-sm text-gray-500">
-                          {r.weekStartDate.substring(0, 10)} ~ {r.weekEndDate.substring(0, 10)}
-                        </div>
-                        <div className="text-xs sm:text-sm text-gray-500">
-                          목표 {r.requiredWorkouts}회 / 실제 {r.actualWorkouts}회
-                        </div>
-                      </div>
-                      {/* <Badge variant={status.variant}>{status.text}</Badge> */}
-                    </div>
-
-                    <div className="grid grid-cols-1 gap-3 sm:gap-4 mt-3">
-                      <div>
-                        <div className="text-[11px] sm:text-xs text-gray-500">벌금</div>
-                        <div className="text-sm sm:text-base font-semibold">{r.penaltyAmount.toLocaleString()}원</div>
-                      </div>
-                      {/* <div>
-                        <div className="text-[11px] sm:text-xs text-gray-500">납부합계</div>
-                        <div className="text-sm sm:text-base font-semibold">{paid.toLocaleString()}원</div>
-                      </div>
-                      <div>
-                        <div className="text-[11px] sm:text-xs text-gray-500">잔여</div>
-                        <div className={`text-sm sm:text-base font-semibold ${remain > 0 ? 'text-red-600' : ''}`}>{remain.toLocaleString()}원</div>
-                      </div> */}
-                    </div>
-                  </button>
-                );
-              })}
+          <div className="space-y-6">
+            {groupedByMember.map(({ memberId, nickname, records }) => {
+              const memberPenaltySum = records.reduce((s, r) => s + r.penaltyAmount, 0);
+              return (
+                <section
+                  key={memberId}
+                  className="rounded-lg border bg-gray-50/50 p-3 sm:p-4 space-y-2 sm:space-y-3"
+                  aria-label={`${nickname} 벌금 내역`}
+                >
+                  <div className="flex items-center justify-between gap-2 pb-2 border-b border-gray-200">
+                    <h3 className="font-semibold text-sm sm:text-base truncate max-w-[70vw] sm:max-w-none">
+                      {nickname}
+                    </h3>
+                    <span className="text-xs sm:text-sm text-gray-600 shrink-0">
+                      기간 내 합계 <strong>{memberPenaltySum.toLocaleString()}원</strong>
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    {records.map((r) => (
+                        <button
+                          key={r.id}
+                          className="w-full text-left border rounded-lg p-3 sm:p-4 bg-white active:opacity-90"
+                          type="button"
+                          aria-label={`${r.weekStartDate.substring(0, 10)} ~ ${r.weekEndDate.substring(0, 10)} 주차 벌금 ${r.penaltyAmount.toLocaleString()}원`}
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="space-y-0.5 sm:space-y-1">
+                              <div className="text-xs sm:text-sm text-gray-500">
+                                {r.weekStartDate.substring(0, 10)} ~ {r.weekEndDate.substring(0, 10)}
+                              </div>
+                              <div className="text-xs sm:text-sm text-gray-500">
+                                목표 {r.requiredWorkouts}회 / 실제 {r.actualWorkouts}회
+                              </div>
+                            </div>
+                          </div>
+                          <div className="grid grid-cols-1 gap-3 sm:gap-4 mt-3">
+                            <div>
+                              <div className="text-[11px] sm:text-xs text-gray-500">벌금</div>
+                              <div className="text-sm sm:text-base font-semibold">{r.penaltyAmount.toLocaleString()}원</div>
+                            </div>
+                          </div>
+                        </button>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
           </div>
         )}
       </CardContent>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -297,8 +297,14 @@ class ApiClient {
     return this.request(`/penalty/rooms/${roomId}/account`, { method: "DELETE" });
   }
 
-  async getPenaltyRecords(roomId: number) {
-    return this.request(`/penalty/rooms/${roomId}/records`);
+  async getPenaltyRecords(
+    roomId: number,
+    params?: { startDate?: string; endDate?: string }
+  ) {
+    const query = params?.startDate != null && params?.endDate != null
+      ? { startDate: params.startDate, endDate: params.endDate }
+      : undefined;
+    return this.request(`/penalty/rooms/${roomId}/records`, query ? { params: query } : {});
   }
 
   async getPenaltyPayments(penaltyRecordId: number) {


### PR DESCRIPTION
Closes #103

## Description

- **API**: `getPenaltyRecords`에 선택적 `startDate`/`endDate` 쿼리 파라미터 지원 추가. 둘 다 있을 때만 기간 필터 요청, 없으면 전체 조회(하위 호환).
- **PenaltyOverview**: 연도별/월간/주간/기간 지정 탭으로 기간 선택 후 해당 구간 벌금 레코드만 조회하도록 연동.
- **문서**: `docs/BACKEND_PENALTY_RECORDS_PERIOD.md`에 백엔드 기간 필터 스펙 정리.