### PR TITLE
PWA 업데이트 배너 및 자동 새로고침 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 import { RequireRole } from '@/components/RequireRole';
+import { PwaUpdateBanner } from '@/components/common/PwaUpdateBanner';
+import { usePwaUpdater } from '@/hooks/usePwaUpdater';
 import Index from './pages/Index';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
@@ -103,17 +105,22 @@ const AppRoutes = () => (
   </Routes>
 );
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <AuthProvider>
-        <BrowserRouter>
-          <AppRoutes />
-        </BrowserRouter>
-      </AuthProvider>
-    </TooltipProvider>
-  </QueryClientProvider>
-);
+const App = () => {
+  const { needRefresh, handleUpdate, dismiss } = usePwaUpdater();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <AuthProvider>
+          <BrowserRouter>
+            <AppRoutes />
+          </BrowserRouter>
+        </AuthProvider>
+        <PwaUpdateBanner visible={needRefresh} onUpdate={handleUpdate} onClose={dismiss} />
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+};
 
 export default App;

--- a/src/components/common/PwaUpdateBanner.tsx
+++ b/src/components/common/PwaUpdateBanner.tsx
@@ -1,0 +1,78 @@
+import type { FC } from 'react';
+import { cn } from '@/lib/utils';
+
+interface PwaUpdateBannerProps {
+  visible: boolean;
+  onUpdate: () => void;
+  onClose?: () => void;
+}
+
+export const PwaUpdateBanner: FC<PwaUpdateBannerProps> = ({ visible, onUpdate, onClose }) => {
+  if (!visible) {
+    return null;
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onUpdate();
+    }
+  };
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-4 sm:pb-6">
+      <div className="w-full max-w-md rounded-lg bg-slate-900 text-slate-50 shadow-lg ring-1 ring-slate-800">
+        <div className="flex items-start gap-3 px-4 py-3 sm:px-5 sm:py-4">
+          <div className="mt-0.5 h-2 w-2 flex-shrink-0 rounded-full bg-emerald-400" aria-hidden="true" />
+          <div className="flex-1 text-sm">
+            <p className="font-medium">새 버전이 준비되었습니다.</p>
+            <p className="mt-1 text-xs text-slate-300">
+              최신 기능과 버그 수정을 적용하려면 지금 새로고침을 진행해 주세요.
+            </p>
+          </div>
+          {onClose && (
+            <button
+              type="button"
+              className={cn(
+                'inline-flex h-7 w-7 items-center justify-center rounded-full',
+                'text-slate-300 hover:bg-slate-800 hover:text-slate-50',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900',
+              )}
+              aria-label="업데이트 배너 닫기"
+              onClick={onClose}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  onClose();
+                }
+              }}
+            >
+              <span className="text-lg leading-none">&times;</span>
+            </button>
+          )}
+        </div>
+        <div className="flex justify-end gap-2 border-t border-slate-800 px-4 py-2.5 sm:px-5">
+          {onClose && (
+            <button
+              type="button"
+              className="rounded-md px-3 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+              onClick={onClose}
+            >
+              나중에
+            </button>
+          )}
+          <button
+            type="button"
+            className="rounded-md bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-slate-900 shadow-sm hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+            onClick={onUpdate}
+            onKeyDown={handleKeyDown}
+            aria-label="지금 업데이트 적용 후 새로고침"
+          >
+            지금 업데이트
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/hooks/usePwaUpdater.tsx
+++ b/src/hooks/usePwaUpdater.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useState } from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error: virtual module provided by vite-plugin-pwa at build time
+import { useRegisterSW } from 'virtual:pwa-register/react';
+
+interface UsePwaUpdaterResult {
+  needRefresh: boolean;
+  handleUpdate: () => void;
+  dismiss: () => void;
+}
+
+export const usePwaUpdater = (): UsePwaUpdaterResult => {
+  const [needRefresh, setNeedRefresh] = useState(false);
+  const [waitingWorker, setWaitingWorker] = useState<ServiceWorker | null>(null);
+
+  const handleNeedRefresh = useCallback<Parameters<typeof useRegisterSW>[0]['onNeedRefresh']>(
+    ({ worker }) => {
+      setNeedRefresh(true);
+      setWaitingWorker(worker ?? null);
+    },
+    [],
+  );
+
+  const handleRegisterError = useCallback<NonNullable<Parameters<typeof useRegisterSW>[0]['onRegisterError']>>(
+    (error) => {
+      console.error('[PWA] service worker registration error', error);
+    },
+    [],
+  );
+
+  const { updateServiceWorker } = useRegisterSW({
+    immediate: true,
+    onNeedRefresh: handleNeedRefresh,
+    onRegisterError: handleRegisterError,
+  });
+
+  const handleUpdate = useCallback(() => {
+    if (!updateServiceWorker) {
+      return;
+    }
+
+    try {
+      // 강제로 대기 중인 SW를 활성화시키고, 활성화 후 페이지를 한 번만 리로드한다.
+      void updateServiceWorker(true)
+        .then(() => {
+          if (waitingWorker) {
+            waitingWorker.postMessage({ type: 'SKIP_WAITING' });
+          }
+        })
+        .finally(() => {
+          window.location.reload();
+        });
+    } catch (error) {
+      console.error('[PWA] update failed', error);
+      window.location.reload();
+    }
+  }, [updateServiceWorker, waitingWorker]);
+
+  const dismiss = useCallback(() => {
+    setNeedRefresh(false);
+  }, []);
+
+  if (import.meta.env.DEV) {
+    return {
+      needRefresh: false,
+      handleUpdate: () => {},
+      dismiss: () => {},
+    };
+  }
+
+  return {
+    needRefresh,
+    handleUpdate,
+    dismiss,
+  };
+};
+


### PR DESCRIPTION
Closes #117

## Description
PWA 업데이트를 감지하고 사용자에게 안내하는 전역 배너 기능을 추가했습니다.

- `usePwaUpdater` 훅을 통해 Service Worker 업데이트 상태(`needRefresh`)를 감지하고, `handleUpdate`, `dismiss` 함수를 제공
- `PwaUpdateBanner` 공통 컴포넌트를 추가하여 업데이트가 있을 때 화면 하단에 고정 배너로 노출
- `App` 컴포넌트에서 훅과 배너를 연결하여, 앱 전역에서 PWA 업데이트를 자연스럽게 안내

사용자는 "지금 업데이트" 버튼으로 즉시 새 버전을 적용하거나, "나중에"를 눌러 배너를 닫을 수 있습니다.