### PR TITLE
운동방 기간(시작/종료일) 의존 제거 및 날짜 유틸 분리

### DIFF
--- a/src/components/PenaltyOverview.tsx
+++ b/src/components/PenaltyOverview.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { api } from '@/lib/api';
-import { formatDateToYmd, getTodayYmd } from '@/lib/workoutRoomRules';
+import { formatDateToYmd, getTodayYmd } from '@/lib/date';
 import { cn } from '@/lib/utils';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';

--- a/src/components/dialogs/AvailableRoomsDialog.tsx
+++ b/src/components/dialogs/AvailableRoomsDialog.tsx
@@ -3,7 +3,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { WorkoutRoom } from '@/types';
-import { format } from 'date-fns';
 import { List, Trophy, Users } from 'lucide-react';
 
 interface AvailableRoomsDialogProps {
@@ -69,10 +68,6 @@ export const AvailableRoomsDialog = ({
                         </span>
                       </div>
                       <div className="text-sm text-muted-foreground">방장: {workoutRoom.ownerNickname}</div>
-                      {/* <div className="text-sm text-muted-foreground">
-                        기간: {format(new Date(workoutRoom.startDate), 'yyyy-MM-dd')} ~{' '}
-                        {workoutRoom.endDate ? format(new Date(workoutRoom.endDate), 'yyyy-MM-dd') : ''}
-                      </div> */}
                       <div className="flex items-center gap-2">
                         <Badge variant={workoutRoom.isActive ? 'default' : 'secondary'}>
                           {workoutRoom.isActive ? '활성' : '비활성'}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -453,9 +453,9 @@ class ApiClient {
 
   /**
    * PUT /admin/workout/rooms/{roomId}
-   * 운동방 규칙 수정 (기간/정원/주간목표/벌금).
+   * 운동방 규칙 수정 (정원/주간목표/벌금).
    * @param roomId - 방 ID
-   * @param body - startDate, endDate(optional), maxMembers, minWeeklyWorkouts, penaltyPerMiss
+   * @param body - maxMembers, minWeeklyWorkouts, penaltyPerMiss
    * @returns WorkoutRoom (updated)
    */
   async updateAdminWorkoutRoom(

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,10 @@
+export function formatDateToYmd(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function getTodayYmd(): string {
+  return formatDateToYmd(new Date());
+}

--- a/src/lib/workoutRoomRules.ts
+++ b/src/lib/workoutRoomRules.ts
@@ -1,92 +1,21 @@
-export function formatDateToYmd(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
-
-export function getTodayYmd(): string {
-  return formatDateToYmd(new Date());
-}
-
-export function parseDateLikeToDate(value?: string | null): Date | undefined {
-  if (!value) return undefined;
-
-  // Prefer stable yyyy-mm-dd parsing (local time).
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (m) {
-    const yyyy = Number(m[1]);
-    const mm = Number(m[2]);
-    const dd = Number(m[3]);
-    const d = new Date(yyyy, mm - 1, dd);
-    return Number.isNaN(d.getTime()) ? undefined : d;
-  }
-
-  // Fallback: ISO-like string.
-  const d = new Date(value);
-  return Number.isNaN(d.getTime()) ? undefined : d;
-}
-
 function toInt(value: string | number): number {
   if (typeof value === 'number') return value;
   return Number.parseInt(value, 10);
 }
 
 export type WorkoutRoomRulesValidationInput = {
-  startDate?: Date;
-  endDate?: Date;
-  enableEndDate: boolean;
   maxMembers: string | number;
   minWeeklyWorkouts: string | number;
   penaltyPerMiss: string | number;
-  todayYmd?: string;
-  /**
-   * When true, start/end date must be today or later.
-   * - CreateRoom: true (default)
-   * - Admin edit: usually false (allow editing already-started rooms)
-   */
-  enforceNotPast?: boolean;
 };
 
 /**
  * Validates room "rules" fields only:
- * - startDate, endDate(optional)
  * - maxMembers
  * - minWeeklyWorkouts
  * - penaltyPerMiss
- *
- * Returns error message (Korean) or null when valid.
  */
 export function validateWorkoutRoomRules(input: WorkoutRoomRulesValidationInput): string | null {
-  // const todayYmd = input.todayYmd ?? getTodayYmd();
-  // const enforceNotPast = input.enforceNotPast ?? true;
-
-  // if (!input.startDate) {
-  //   return '운동 인증 시작일을 설정해주세요.';
-  // }
-
-  // if (enforceNotPast && formatDateToYmd(input.startDate) < todayYmd) {
-  //   return '시작일은 오늘 이후여야 합니다.';
-  // }
-
-  // // Start date: Monday only (CreateRoom UX rule)
-  // if (input.startDate.getDay() !== 1) {
-  //   return '시작일은 월요일만 선택 가능합니다.';
-  // }
-
-  // if (input.enableEndDate && input.endDate) {
-  //   if (input.startDate >= input.endDate) {
-  //     return '종료일은 시작일보다 늦어야 합니다.';
-  //   }
-  //   if (enforceNotPast && formatDateToYmd(input.endDate) < todayYmd) {
-  //     return '종료일은 오늘 이후여야 합니다.';
-  //   }
-  //   // End date: Sunday only (CreateRoom UX rule)
-  //   if (input.endDate.getDay() !== 0) {
-  //     return '종료일은 일요일만 선택 가능합니다.';
-  //   }
-  // }
-
   const minWorkouts = toInt(input.minWeeklyWorkouts);
   if (Number.isNaN(minWorkouts) || minWorkouts < 1 || minWorkouts > 7) {
     return '주간 최소 운동 횟수는 1-7회 사이여야 합니다.';
@@ -98,8 +27,8 @@ export function validateWorkoutRoomRules(input: WorkoutRoomRulesValidationInput)
   }
 
   const maxMembersNum = toInt(input.maxMembers);
-  if (Number.isNaN(maxMembersNum) || maxMembersNum < 2 || maxMembersNum > 10) {
-    return '참여 인원은 2명 이상 10명 이하여야 합니다.';
+  if (Number.isNaN(maxMembersNum) || maxMembersNum < 1 || maxMembersNum > 10) {
+    return '참여 인원은 1명 이상 10명 이하여야 합니다.';
   }
 
   return null;

--- a/src/pages/CreateRoomPage.tsx
+++ b/src/pages/CreateRoomPage.tsx
@@ -1,20 +1,14 @@
-import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { Layout } from '@/components/layout/Layout';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Calendar } from '@/components/ui/calendar';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
-import { CalendarIcon, Loader2 } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { Checkbox } from '@/components/ui/checkbox';
 import { api } from '@/lib/api';
-import { formatDateToYmd, getTodayYmd, validateWorkoutRoomRules } from '@/lib/workoutRoomRules';
+import { validateWorkoutRoomRules } from '@/lib/workoutRoomRules';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 type CreateRoomLocationState = { hasReachedRoomLimit?: boolean; joinedRoomCount?: number; isAdmin?: boolean } | undefined;
 
@@ -26,14 +20,9 @@ export const CreateRoomPage = () => {
   const [entryCode, setEntryCode] = useState('');
   const [minWeeklyWorkouts, setMinWeeklyWorkouts] = useState('3');
   const [penaltyPerMiss, setPenaltyPerMiss] = useState('5000');
-  const [startDate, setStartDate] = useState<Date>();
-  const [endDate, setEndDate] = useState<Date>();
-  const [enableEndDate, setEnableEndDate] = useState(false);
   const [maxMembers, setMaxMembers] = useState('10');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-
-  const today = getTodayYmd();
 
   const generateRandomEntryCode = () => {
     const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // 혼동 가능 문자 제외 (0,O,1,I)
@@ -60,13 +49,9 @@ export const CreateRoomPage = () => {
     }
 
     const rulesError = validateWorkoutRoomRules({
-      startDate,
-      endDate,
-      enableEndDate,
       maxMembers,
       minWeeklyWorkouts,
       penaltyPerMiss,
-      todayYmd: today,
     });
     if (rulesError) {
       setError(rulesError);
@@ -105,8 +90,6 @@ export const CreateRoomPage = () => {
         name: roomName.trim(),
         minWeeklyWorkouts: parseInt(minWeeklyWorkouts),
         penaltyPerMiss: parseInt(penaltyPerMiss),
-        // startDate: formatDateToYmd(startDate),
-        // endDate: enableEndDate && endDate ? formatDateToYmd(endDate) : null,
         maxMembers: parseInt(maxMembers),
         entryCode: entryCode.trim(),
       };
@@ -174,98 +157,20 @@ export const CreateRoomPage = () => {
                 </div>
               </div>
 
-              {/* <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label>시작일 *</Label>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "w-full justify-start text-left font-normal",
-                          !startDate && "text-muted-foreground"
-                        )}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {startDate ? (
-                          format(startDate, "PPP", { locale: ko })
-                        ) : (
-                          <span>시작일 선택</span>
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0">
-                      <Calendar
-                        mode="single"
-                        selected={startDate}
-                        onSelect={setStartDate}
-                        disabled={(date) => {
-                          const formattedDate = formatDateToYmd(date);
-                          return formattedDate < today || date.getDay() !== 1;
-                        }}
-                        initialFocus
-                      />
-                    </PopoverContent>
-                  </Popover>
-                  <p className="text-xs text-gray-500">매주 월요일만 선택 가능합니다.</p>
-                </div>
-
-                <div className="space-y-4">
-                  <div className="flex items-center gap-2 ">
-                    <Label className="mb-0">종료일</Label>
-                    <Checkbox id="enable-end-date" checked={enableEndDate} onCheckedChange={(checked) => {
-                      setEnableEndDate(!!checked);
-                      if (!checked) setEndDate(undefined);
-                    }} />
-                    <span className="text-xs text-gray-500">종료일 설정</span>
-                  </div>
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "w-full justify-start text-left font-normal",
-                          (!endDate || !enableEndDate) && "text-muted-foreground"
-                        )}
-                        disabled={!enableEndDate}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {endDate && enableEndDate ? (
-                          format(endDate, "PPP", { locale: ko })
-                        ) : (
-                          <span>종료일 선택</span>
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0">
-                      <Calendar
-                        mode="single"
-                        selected={endDate}
-                        onSelect={setEndDate}
-                        disabled={(date) => {
-                          const formattedDate = formatDateToYmd(date);
-                          return formattedDate < today || date.getDay() !== 0;
-                        }}
-                        initialFocus
-                      />
-                    </PopoverContent>
-                  </Popover>
-                  <p className="text-xs text-gray-500" style={{marginTop: 7}}>매주 일요일만 선택 가능합니다.</p>
-                </div>
-              </div> */}
-
               <div className="space-y-2">
                 <Label htmlFor="max-members">최대 참여 인원</Label>
                 <Input
                   id="max-members"
                   type="number"
-                  min="2"
+                  min="1"
                   max="10"
                   value={maxMembers}
                   onChange={(e) => setMaxMembers(e.target.value)}
                   className="max-w-xs"
                 />
-                <p className="text-xs text-gray-500">방장 포함 최대 참여 가능한 인원수</p>
+                <p className="text-xs text-gray-500">
+                  방장 포함 최대 참여 가능한 인원수 (혼자서 운동 인증 하기를 원하면 1로 설정)
+                </p>
               </div>
 
               <div className="space-y-2">

--- a/src/pages/JoinedRoomsPage.tsx
+++ b/src/pages/JoinedRoomsPage.tsx
@@ -6,7 +6,6 @@ import { api } from '@/lib/api';
 import { WorkoutRoom } from '@/types';
 import { Eye, List, Users } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { format } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
 
 const JoinedRoomsPage = () => {
@@ -83,9 +82,6 @@ const JoinedRoomsPage = () => {
                     </span>
                   </div>
                   <div className="text-sm text-muted-foreground">방장: {room.ownerNickname}</div>
-                  {/* <div className="text-sm text-muted-foreground">
-                    기간: {format(new Date(room.startDate), 'yyyy-MM-dd')} ~ {room.endDate ? format(new Date(room.endDate), 'yyyy-MM-dd') : ''}
-                  </div> */}
                   <div className="pt-1">
                     <Badge variant={room.isActive ? 'default' : 'secondary'}>{room.isActive ? '활성' : '비활성'}</Badge>
                   </div>

--- a/src/pages/admin/AdminRoomDetailPage.tsx
+++ b/src/pages/admin/AdminRoomDetailPage.tsx
@@ -1,22 +1,16 @@
 import { Layout } from '@/components/layout/Layout';
 import { useParams, Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft, CalendarIcon, Loader2, Save } from 'lucide-react';
+import { ArrowLeft, Loader2, Save } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Calendar } from '@/components/ui/calendar';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { toast } from '@/components/ui/sonner';
 import { api } from '@/lib/api';
-import { cn } from '@/lib/utils';
-import { formatDateToYmd, getTodayYmd, parseDateLikeToDate, validateWorkoutRoomRules } from '@/lib/workoutRoomRules';
+import { validateWorkoutRoomRules } from '@/lib/workoutRoomRules';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
 import { useEffect, useMemo, useState } from 'react';
 import { AdminStateBlock } from '@/components/admin/AdminStateBlock';
 
@@ -25,7 +19,6 @@ const AdminRoomDetailPage = () => {
   const queryClient = useQueryClient();
 
   const numericRoomId = useMemo(() => Number(roomId), [roomId]);
-  const todayYmd = useMemo(() => getTodayYmd(), []);
 
   const detailQuery = useQuery({
     queryKey: ['adminWorkoutRoomDetail', numericRoomId],
@@ -37,9 +30,6 @@ const AdminRoomDetailPage = () => {
   const room = detailQuery.data?.workoutRoomInfo ?? null;
 
   const [initialized, setInitialized] = useState(false);
-  const [startDate, setStartDate] = useState<Date | undefined>(undefined);
-  const [endDate, setEndDate] = useState<Date | undefined>(undefined);
-  const [enableEndDate, setEnableEndDate] = useState(false);
   const [maxMembers, setMaxMembers] = useState('10');
   const [minWeeklyWorkouts, setMinWeeklyWorkouts] = useState('3');
   const [penaltyPerMiss, setPenaltyPerMiss] = useState('5000');
@@ -49,18 +39,10 @@ const AdminRoomDetailPage = () => {
   useEffect(() => {
     setInitialized(false);
     setLocalError('');
-    setStartDate(undefined);
-    setEndDate(undefined);
-    setEnableEndDate(false);
   }, [numericRoomId]);
 
   const hydrateFromRoom = (r: typeof room) => {
     if (!r) return;
-    const sd = parseDateLikeToDate(r.startDate);
-    const ed = parseDateLikeToDate(r.endDate);
-    setStartDate(sd);
-    setEndDate(ed);
-    setEnableEndDate(Boolean(ed));
     setMaxMembers(String(r.maxMembers ?? 10));
     setMinWeeklyWorkouts(String(r.minWeeklyWorkouts ?? 3));
     setPenaltyPerMiss(String(r.penaltyPerMiss ?? 5000));
@@ -77,21 +59,13 @@ const AdminRoomDetailPage = () => {
       if (!Number.isFinite(numericRoomId)) throw new Error('유효하지 않은 roomId 입니다.');
 
       const error = validateWorkoutRoomRules({
-        startDate,
-        endDate,
-        enableEndDate,
         maxMembers,
         minWeeklyWorkouts,
         penaltyPerMiss,
-        todayYmd,
-        enforceNotPast: false,
       });
       if (error) throw new Error(error);
 
-      // startDate is guaranteed by validation.
       const body = {
-        startDate: formatDateToYmd(startDate as Date),
-        endDate: enableEndDate && endDate ? formatDateToYmd(endDate) : null,
         maxMembers: Number.parseInt(maxMembers, 10),
         minWeeklyWorkouts: Number.parseInt(minWeeklyWorkouts, 10),
         penaltyPerMiss: Number.parseInt(penaltyPerMiss, 10),
@@ -156,83 +130,9 @@ const AdminRoomDetailPage = () => {
               <Card>
                 <CardHeader>
                   <CardTitle>규칙 설정</CardTitle>
-                  <CardDescription>기간 / 정원 / 주간 목표 / 벌금 규칙을 수정합니다.</CardDescription>
+                  <CardDescription>정원 / 주간 목표 / 벌금 규칙을 수정합니다.</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-6">
-                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label className="text-xs md:text-sm">시작일 *</Label>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            variant="outline"
-                            className={cn('w-full justify-start text-left font-normal', !startDate && 'text-muted-foreground')}
-                          >
-                            <CalendarIcon className="mr-2 h-4 w-4" />
-                            {startDate ? format(startDate, 'PPP', { locale: ko }) : <span>시작일 선택</span>}
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0">
-                          <Calendar
-                            mode="single"
-                            selected={startDate}
-                            onSelect={setStartDate}
-                            disabled={(date) => {
-                              return date.getDay() !== 1;
-                            }}
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                      <p className="text-xs text-muted-foreground">매주 월요일만 선택 가능합니다.</p>
-                    </div>
-
-                    <div className="space-y-4">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Label className="mb-0 text-xs md:text-sm">종료일</Label>
-                        <Checkbox
-                          id="admin-enable-end-date"
-                          checked={enableEndDate}
-                          onCheckedChange={(checked) => {
-                            const enabled = Boolean(checked);
-                            setEnableEndDate(enabled);
-                            if (!enabled) setEndDate(undefined);
-                          }}
-                        />
-                        <span className="text-xs text-muted-foreground">종료일 설정</span>
-                      </div>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            variant="outline"
-                            className={cn(
-                              'w-full justify-start text-left font-normal',
-                              (!endDate || !enableEndDate) && 'text-muted-foreground'
-                            )}
-                            disabled={!enableEndDate}
-                          >
-                            <CalendarIcon className="mr-2 h-4 w-4" />
-                            {endDate && enableEndDate ? format(endDate, 'PPP', { locale: ko }) : <span>종료일 선택</span>}
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent className="w-auto p-0">
-                          <Calendar
-                            mode="single"
-                            selected={endDate}
-                            onSelect={setEndDate}
-                            disabled={(date) => {
-                              return date.getDay() !== 0;
-                            }}
-                            initialFocus
-                          />
-                        </PopoverContent>
-                      </Popover>
-                      <p className="text-xs text-muted-foreground" style={{ marginTop: 7 }}>
-                        매주 일요일만 선택 가능합니다.
-                      </p>
-                    </div>
-                  </div>
-
                   <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                     <div className="space-y-2">
                       <Label htmlFor="admin-max-members" className="text-xs md:text-sm">

--- a/src/pages/admin/AdminRoomsPage.tsx
+++ b/src/pages/admin/AdminRoomsPage.tsx
@@ -26,16 +26,6 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 
 type ActiveFilter = 'ALL' | 'ACTIVE' | 'INACTIVE';
 
-function formatDate(isoLike?: string) {
-  if (!isoLike) return '-';
-  const date = new Date(isoLike);
-  if (Number.isNaN(date.getTime())) return isoLike;
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
-
 function getErrorMessage(err: unknown) {
   if (err instanceof Error) return err.message;
   return '요청에 실패했습니다. 잠시 후 다시 시도해주세요.';
@@ -243,7 +233,6 @@ const AdminRoomsPage = () => {
                     const rulesText = `주 ${r.minWeeklyWorkouts ?? 0}회 · 미달 ${(
                       r.penaltyPerMiss ?? 0
                     ).toLocaleString()}원`;
-                    const periodText = `${formatDate(r.startDate)} ~ ${formatDate(r.endDate)}`;
                     const isDeletingThisRow = deleteMutation.isPending && pendingDelete.target?.id === r.id;
 
                     return (
@@ -272,12 +261,6 @@ const AdminRoomsPage = () => {
                             <div className="tabular-nums text-sm text-foreground">{membersText}</div>
                           </div>
                           <div className="space-y-0.5">
-                            <div className="font-medium text-[11px] uppercase tracking-wide text-foreground/70">
-                              기간
-                            </div>
-                            <div className="text-sm">{periodText}</div>
-                          </div>
-                          <div className="col-span-2 space-y-0.5">
                             <div className="font-medium text-[11px] uppercase tracking-wide text-foreground/70">
                               규칙
                             </div>
@@ -316,7 +299,6 @@ const AdminRoomsPage = () => {
                           <TableHead className="w-[140px]">방장</TableHead>
                           <TableHead className="w-[110px]">상태</TableHead>
                           <TableHead className="w-[150px] text-right">인원</TableHead>
-                          <TableHead className="w-[220px]">기간</TableHead>
                           <TableHead className="w-[220px]">규칙</TableHead>
                           <TableHead className="w-[180px] text-right">작업</TableHead>
                         </TableRow>
@@ -341,9 +323,6 @@ const AdminRoomsPage = () => {
                                 <Badge variant={r.isActive ? 'default' : 'secondary'}>{activeLabel}</Badge>
                               </TableCell>
                               <TableCell className="text-right tabular-nums">{membersText}</TableCell>
-                              <TableCell className="text-sm text-muted-foreground">
-                                {formatDate(r.startDate)} ~ {formatDate(r.endDate)}
-                              </TableCell>
                               <TableCell className="text-sm text-muted-foreground">{rulesText}</TableCell>
                               <TableCell className="text-right">
                                 <div className="flex items-center justify-end gap-2">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,8 +23,6 @@ export interface WorkoutRoom {
   name: string;
   minWeeklyWorkouts: number;
   penaltyPerMiss: number;
-  startDate: string;
-  endDate: string | null;
   maxMembers: number;
   currentMembers: number;
   ownerNickname: string;
@@ -297,8 +295,6 @@ export interface AdminWorkoutRoomListParams {
 }
 
 export interface AdminUpdateRoomRequest {
-  startDate: string;
-  endDate?: string | null;
   maxMembers: number;
   minWeeklyWorkouts: number;
   penaltyPerMiss: number;


### PR DESCRIPTION
Closes #120

## Description
- 운동방 생성/관리/목록 화면에서 기간(시작일/종료일) 입력 및 표시를 제거했습니다.
- `validateWorkoutRoomRules`를 규칙(정원/주간 목표/벌금) 검증에만 집중하도록 단순화했습니다.
- 날짜 유틸(`formatDateToYmd`, `getTodayYmd`)을 `src/lib/date.ts`로 분리하고 사용처를 정리했습니다.
- 관련 타입 및 관리자 규칙 수정 API 설명에서 기간 필드를 제거했습니다.