### PR TITLE
관리자 운동방 채팅 내역 조회 및 멤버 관리 UI 개선

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-54d0af47'], (function (workbox) { 'use strict';
     "revision": "d41d8cd98f00b204e9800998ecf8427e"
   }, {
     "url": "index.html",
-    "revision": "0.n6vp9t3h738"
+    "revision": "0.apn7vh5mjvs"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/docs/admin-room-chat-backend.md
+++ b/docs/admin-room-chat-backend.md
@@ -1,0 +1,87 @@
+## 관리자 운동방 채팅 내역 조회 API
+
+관리자 화면(운동방 상세 → **채팅** 탭)에서 방 멤버들의 채팅 내역을 **읽기 전용**으로 조회하기 위한 API입니다.  
+멤버용 `GET /chat/rooms/{roomId}/messages`와 **동일한 응답 스키마**를 사용하며, **ADMIN 역할**만 호출할 수 있습니다.
+
+---
+
+## 1. 엔드포인트
+
+| 항목 | 내용 |
+|------|------|
+| Method / Path | `GET /api/admin/workout/rooms/{roomId}/messages` |
+| Auth | `ADMIN` 역할 필수 (`Authorization: Bearer …`) |
+| Path variable | `roomId` — 운동방 ID |
+| Query | `cursorId` (optional), `size` (optional, default `20`, max 권장 `50`) |
+
+### 1.1. Query 파라미터
+
+- `size`: 한 번에 가져올 메시지 개수 (기본 20)
+- `cursorId`: **더 오래된** 메시지 페이지 조회 시 사용. 멤버용 채팅 API와 동일한 커서 규칙을 따릅니다.
+  - 최초 요청: `cursorId` 생략 → 최신 `size`건
+  - 이전 대화: 응답의 `nextCursorId`를 다음 요청의 `cursorId`로 전달
+
+### 1.2. 권한
+
+- 요청자는 **방 멤버일 필요 없음** (관리자만 `ADMIN` 역할이면 됨).
+- `roomId`에 해당하는 운동방이 존재하지 않으면 `404`.
+- `ADMIN`이 아니면 `403`.
+
+---
+
+## 2. 응답 스키마
+
+프론트엔드 타입 (`src/types/index.ts`) 기준:
+
+```ts
+export interface ChatMessage {
+  id: string;
+  sender: string;
+  content: string;
+  timestamp: string;
+  type: 'TEXT' | 'IMAGE' | 'READ_STATUS' | 'SYSTEM';
+  imageUrl?: string;
+  unreadCount?: number;
+}
+
+export interface ChatHistoryResponse {
+  messages: ChatMessage[];
+  nextCursorId: number | null;
+  hasNext: boolean;
+}
+```
+
+### 2.1. 정렬 및 페이지네이션
+
+- **멤버용** `GET /chat/rooms/{roomId}/messages`와 동일한 정렬·커서 동작을 권장합니다.
+- 응답 `messages` 배열은 프론트에서 **오래된 순 → 최신 순**으로 표시하기 위해, 필요 시 클라이언트에서 재정렬하거나 API가 이미 시간순 오름차순이면 그대로 사용합니다.
+- `hasNext: true`이고 `nextCursorId`가 있으면, 더 오래된 메시지가 존재함.
+
+### 2.2. unreadCount (선택)
+
+- 관리자 조회 화면에서는 `unreadCount`를 표시하지 않지만, 스키마 호환을 위해 멤버 API와 동일하게 내려도 무방합니다.
+
+---
+
+## 3. 구현 참고
+
+- 메시지 저장소·조회 로직은 기존 채팅 도메인을 재사용하고, **인가(Authorization) 레이어만** `ADMIN` + `roomId` 검증으로 분리하는 방식이 적합합니다.
+- `READ_STATUS`, `SYSTEM` 타입 메시지는 프론트에서 목록에서 제외합니다 (`isSystemChatType`).
+
+---
+
+## 4. 프론트엔드 연동
+
+- API 클라이언트: `api.getAdminChatHistory(roomId, cursorId?, size?)`
+- UI: `src/components/admin/AdminRoomChatTab.tsx` (읽기 전용, WebSocket·전송 없음)
+
+---
+
+## 5. 에러 코드 (권장)
+
+| HTTP | 설명 |
+|------|------|
+| 200 | 성공 |
+| 403 | ADMIN 아님 |
+| 404 | `roomId` 없음 |
+| 401 | 미인증 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2356,7 +2355,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.6.tgz",
       "integrity": "sha512-4uyt8BOrBsSq6i4yiOV/gG6BnnrvTeyymlNcaN/dKvyU1GoolxAafvIvaNP1RCGPlNab3OuE4MKUQuv2lH+PLQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -2423,7 +2421,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.6.tgz",
       "integrity": "sha512-YYGARbutghQY4zZUWMYia0ib0Y/rb52y72/N0z3vglRHL7ii/AaK9SA7S/dzScVOlCdnbHXz+sc5Dq+r8fwFAg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.6",
         "@firebase/component": "0.7.0",
@@ -2439,8 +2436,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.6.1",
@@ -2891,7 +2887,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -5772,7 +5767,6 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5784,7 +5778,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5849,7 +5842,6 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -6067,7 +6059,6 @@
       "integrity": "sha512-MCbrb508JZHqe7bUibmZj/lyojdhLRnfkmyXnkrCM2zVrjTgL89U8UEfInpKTvPeTnxsw2hmyZxnhsdNR6yhwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cac": "^6.7.14",
         "colorette": "^2.0.20",
@@ -6106,7 +6097,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6472,7 +6462,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -7096,7 +7085,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -7309,8 +7297,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -7542,7 +7529,6 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9772,7 +9758,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10049,7 +10034,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10076,7 +10060,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10090,7 +10073,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
       "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -11254,7 +11236,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11344,7 +11325,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -11433,7 +11413,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11605,7 +11584,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11931,7 +11909,6 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -12766,7 +12743,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12843,7 +12819,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/src/components/admin/AdminRoomChatTab.tsx
+++ b/src/components/admin/AdminRoomChatTab.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { api } from '@/lib/api';
+import type { ChatMessage, RoomMember } from '@/types';
+import { isSystemChatType } from '@/types';
+import { AdminStateBlock } from '@/components/admin/AdminStateBlock';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+
+type AdminRoomChatTabProps = {
+  roomId: number;
+  members: RoomMember[];
+  active: boolean;
+};
+
+type ChatMessageWithDisplay = ChatMessage & {
+  displayTime?: string;
+  displayDate?: string;
+  isFirstOfGroup?: boolean;
+  showAvatar?: boolean;
+  showNickname?: boolean;
+  profileUrl?: string;
+};
+
+const formatTimestamp = (timestamp?: string | number | Date | null): string => {
+  if (!timestamp) return '';
+  try {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return '';
+    const hours = date.getHours();
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    const period = hours < 12 ? '오전' : '오후';
+    const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+    return `${period} ${hour12}:${minutes}`;
+  } catch {
+    return '';
+  }
+};
+
+const formatDateLabel = (timestamp?: string | number | Date | null): string => {
+  if (!timestamp) return '';
+  try {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return '';
+    const today = new Date();
+    const isSameDay =
+      date.getFullYear() === today.getFullYear() &&
+      date.getMonth() === today.getMonth() &&
+      date.getDate() === today.getDate();
+
+    if (isSameDay) return '오늘';
+
+    const weekdayNames = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
+    const weekday = weekdayNames[date.getDay()];
+    return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ${weekday}`;
+  } catch {
+    return '';
+  }
+};
+
+const decorateMessages = (
+  rawMessages: ChatMessageWithDisplay[],
+  memberByNickname: Map<string, RoomMember>,
+): ChatMessageWithDisplay[] => {
+  return rawMessages.map((msg, index, arr) => {
+    const prev = arr[index - 1];
+    const currentDateLabel = formatDateLabel(msg.timestamp);
+    const prevDateLabel = prev ? formatDateLabel(prev.timestamp) : undefined;
+    const isDifferentSender = !prev || prev.sender !== msg.sender;
+    const isDifferentDate = !prev || currentDateLabel !== prevDateLabel;
+    const isFirstOfGroup = isDifferentSender || isDifferentDate;
+    const memberInfo = memberByNickname.get(msg.sender);
+
+    return {
+      ...msg,
+      displayTime: msg.displayTime ?? formatTimestamp(msg.timestamp),
+      displayDate: currentDateLabel,
+      isFirstOfGroup,
+      showAvatar: isFirstOfGroup,
+      showNickname: isFirstOfGroup,
+      profileUrl: memberInfo?.profileUrl,
+    };
+  });
+};
+
+export const AdminRoomChatTab = ({ roomId, members, active }: AdminRoomChatTabProps) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [messages, setMessages] = useState<ChatMessageWithDisplay[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [hasFetched, setHasFetched] = useState(false);
+  const [enlargedImageUrl, setEnlargedImageUrl] = useState<string | null>(null);
+
+  const memberByNickname = useMemo(
+    () => new Map(members.map((m) => [m.nickname, m])),
+    [members],
+  );
+
+  const visibleMessages = useMemo(
+    () => messages.filter((msg) => !isSystemChatType(msg.type)),
+    [messages],
+  );
+
+  const loadInitial = useCallback(async () => {
+    if (!Number.isFinite(roomId)) return;
+    setIsInitialLoading(true);
+    setLoadError(null);
+    try {
+      const { messages: initialMessages, nextCursorId, hasNext } = await api.getAdminChatHistory(roomId);
+      const mapped = (initialMessages ?? []).map((msg) => ({
+        ...msg,
+        displayTime: formatTimestamp(msg.timestamp),
+        displayDate: formatDateLabel(msg.timestamp),
+      }));
+      setMessages(decorateMessages(mapped, memberByNickname));
+      setNextCursor(nextCursorId);
+      setHasMore(hasNext);
+      setHasFetched(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '채팅 내역을 불러오지 못했습니다.';
+      setLoadError(msg);
+      setHasFetched(true);
+    } finally {
+      setIsInitialLoading(false);
+    }
+  }, [roomId, memberByNickname]);
+
+  useEffect(() => {
+    if (!active || hasFetched) return;
+    void loadInitial();
+  }, [active, hasFetched, loadInitial]);
+
+  useEffect(() => {
+    setMessages([]);
+    setNextCursor(null);
+    setHasMore(false);
+    setLoadError(null);
+    setHasFetched(false);
+    setEnlargedImageUrl(null);
+  }, [roomId]);
+
+  useEffect(() => {
+    if (!hasFetched || isInitialLoading || loadError) return;
+    const scrollContainer = scrollContainerRef.current;
+    if (scrollContainer) {
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    }
+  }, [hasFetched, isInitialLoading, loadError, visibleMessages.length]);
+
+  const fetchOlderMessages = useCallback(async () => {
+    if (!hasMore || isLoadingOlder || nextCursor == null) return;
+
+    setIsLoadingOlder(true);
+    try {
+      const { messages: olderMessages, nextCursorId, hasNext } = await api.getAdminChatHistory(
+        roomId,
+        nextCursor,
+      );
+
+      const scrollContainer = scrollContainerRef.current;
+      const prevScrollHeight = scrollContainer?.scrollHeight ?? 0;
+
+      const mappedOlder = (olderMessages ?? []).map((msg) => ({
+        ...msg,
+        displayTime: formatTimestamp(msg.timestamp),
+        displayDate: formatDateLabel(msg.timestamp),
+      }));
+
+      setMessages((prev) => decorateMessages([...mappedOlder, ...prev], memberByNickname));
+      setNextCursor(nextCursorId);
+      setHasMore(hasNext);
+
+      if (scrollContainer) {
+        requestAnimationFrame(() => {
+          scrollContainer.scrollTop = scrollContainer.scrollHeight - prevScrollHeight;
+        });
+      }
+    } catch (err) {
+      console.error('Failed to fetch older admin chat messages:', err);
+    } finally {
+      setIsLoadingOlder(false);
+    }
+  }, [roomId, nextCursor, hasMore, isLoadingOlder, memberByNickname]);
+
+  const handleScroll = useCallback(() => {
+    const scrollTop = scrollContainerRef.current?.scrollTop ?? 0;
+    if (scrollTop <= 20) {
+      void fetchOlderMessages();
+    }
+  }, [fetchOlderMessages]);
+
+  const handleImageKeyDown = useCallback((e: React.KeyboardEvent, url: string) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setEnlargedImageUrl(url);
+    }
+  }, []);
+
+  if (!active) {
+    return null;
+  }
+
+  if (isInitialLoading) {
+    return <AdminStateBlock variant="loading" />;
+  }
+
+  if (loadError) {
+    return (
+      <AdminStateBlock
+        variant="error"
+        title="채팅 내역을 불러오지 못했습니다."
+        description={loadError}
+        onAction={() => setHasFetched(false)}
+        actionLabel="다시 시도"
+      />
+    );
+  }
+
+  if (hasFetched && visibleMessages.length === 0) {
+    return <AdminStateBlock variant="empty" description="채팅 내역이 없습니다." />;
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base md:text-lg">채팅 내역</CardTitle>
+          <CardDescription>방 멤버들의 채팅 메시지를 읽기 전용으로 조회합니다.</CardDescription>
+        </CardHeader>
+        <CardContent className="p-4 sm:p-6">
+          <div
+            ref={scrollContainerRef}
+            onScroll={handleScroll}
+            className="flex min-h-[50vh] max-h-[60vh] flex-col overflow-x-hidden overflow-y-auto rounded-md bg-muted px-3 py-2 sm:min-h-[400px] sm:px-4 sm:py-3"
+            role="log"
+            aria-label="채팅 메시지 목록"
+          >
+            {isLoadingOlder && (
+              <div className="flex items-center justify-center p-2">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" aria-hidden />
+              </div>
+            )}
+            {!hasMore && visibleMessages.length > 0 && (
+              <div className="mb-2 text-center text-[11px] text-muted-foreground">
+                이전 대화가 더 이상 없습니다.
+              </div>
+            )}
+            {visibleMessages.map((msg, index) => {
+              const prev = visibleMessages[index - 1];
+              const showDateDivider = !prev || prev.displayDate !== msg.displayDate;
+              const isFirstOfGroup = msg.isFirstOfGroup ?? true;
+
+              return (
+                <div key={msg.id}>
+                  {showDateDivider && msg.displayDate && (
+                    <div className="my-3 flex items-center justify-center">
+                      <span className="rounded-full border border-border bg-background px-3 py-1 text-[11px] text-muted-foreground">
+                        {msg.displayDate}
+                      </span>
+                    </div>
+                  )}
+                  <div
+                    className={`flex min-w-0 w-full justify-start ${isFirstOfGroup ? 'mt-2' : 'mt-0.5'}`}
+                  >
+                    <div className="mr-1.5 flex shrink-0 flex-col items-center">
+                      {msg.showAvatar ? (
+                        <Avatar className="h-8 w-8 shrink-0">
+                          <AvatarImage src={msg.profileUrl} alt={msg.sender} />
+                          <AvatarFallback className="text-xs">
+                            {msg.sender?.slice(0, 2).toUpperCase() ?? '?'}
+                          </AvatarFallback>
+                        </Avatar>
+                      ) : (
+                        <div className="h-8 w-8" aria-hidden />
+                      )}
+                    </div>
+                    <div className="flex min-w-0 max-w-[78%] flex-col items-start">
+                      {msg.showNickname && (
+                        <span className="mb-0.5 text-xs text-muted-foreground">{msg.sender}</span>
+                      )}
+                      <div className="flex min-w-0 items-end gap-1">
+                        {msg.type === 'IMAGE' ? (
+                          <button
+                            type="button"
+                            onClick={() => msg.imageUrl && setEnlargedImageUrl(msg.imageUrl)}
+                            onKeyDown={(e) => msg.imageUrl && handleImageKeyDown(e, msg.imageUrl)}
+                            className="cursor-pointer rounded-lg p-0 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                            aria-label="이미지 크게 보기"
+                          >
+                            <img
+                              src={msg.imageUrl}
+                              alt="첨부 이미지"
+                              className="max-h-40 max-w-[200px] rounded-lg"
+                            />
+                          </button>
+                        ) : (
+                          <span className="max-w-full whitespace-pre-wrap break-words rounded-2xl rounded-bl-md border border-border bg-card px-3 py-2 text-sm text-card-foreground shadow-sm">
+                            {msg.content}
+                          </span>
+                        )}
+                        <span className="shrink-0 pb-0.5 text-[10px] text-muted-foreground">
+                          {msg.displayTime}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={!!enlargedImageUrl} onOpenChange={() => setEnlargedImageUrl(null)}>
+        <DialogContent className="max-w-[min(100vw-2rem,42rem)] border-0 bg-transparent p-0 shadow-none">
+          {enlargedImageUrl ? (
+            <img
+              src={enlargedImageUrl}
+              alt="채팅 이미지 확대"
+              className="max-h-[85vh] w-full rounded-lg object-contain"
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/src/components/admin/AdminRoomMembersTab.tsx
+++ b/src/components/admin/AdminRoomMembersTab.tsx
@@ -1,0 +1,547 @@
+import { useEffect, useMemo, useState } from 'react';
+import { format, startOfDay, endOfDay } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { Award, Calendar, ChevronRight, Target } from 'lucide-react';
+import type { RestInfo, RoomMember, WorkoutRecord } from '@/types';
+import { AdminStateBlock } from '@/components/admin/AdminStateBlock';
+import { PenaltyOverview } from '@/components/PenaltyOverview';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  type CarouselApi,
+} from '@/components/ui/carousel';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
+
+type AdminRoomMembersTabProps = {
+  roomId: number;
+  ownerNickname: string;
+  minWeeklyWorkouts: number;
+  members: RoomMember[];
+};
+
+type MemberDetailContentProps = {
+  member: RoomMember;
+  ownerNickname: string;
+  minWeeklyWorkouts: number;
+  sortedRecords: WorkoutRecord[];
+  onZoomImages: (urls: string[], index?: number) => void;
+};
+
+const formatJoinedDate = (isoLike?: string): string => {
+  if (!isoLike) return '-';
+  const date = new Date(isoLike);
+  if (Number.isNaN(date.getTime())) return isoLike;
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+const isMemberOnRestToday = (member: RoomMember): boolean => {
+  const todayDate = startOfDay(new Date());
+  return member.restInfoList.some((restInfo: RestInfo) => {
+    const startDate = startOfDay(new Date(restInfo.startDate));
+    const endDate = endOfDay(new Date(restInfo.endDate));
+    return todayDate >= startDate && todayDate <= endDate;
+  });
+};
+
+const sortWorkoutRecords = (records: WorkoutRecord[]): WorkoutRecord[] =>
+  [...records].sort((a, b) => b.workoutDate.localeCompare(a.workoutDate));
+
+const MemberDetailContent = ({
+  member,
+  ownerNickname,
+  minWeeklyWorkouts,
+  sortedRecords,
+  onZoomImages,
+}: MemberDetailContentProps) => {
+  const isOwner = member.nickname === ownerNickname;
+  const onRest = member.isOnBreak || isMemberOnRestToday(member);
+
+  return (
+    <div className="space-y-4 pb-2">
+      <div className="flex flex-col items-center gap-3 border-b pb-4">
+        <Avatar className="h-16 w-16 sm:h-20 sm:w-20">
+          <AvatarImage src={member.profileUrl} alt={member.nickname} />
+          <AvatarFallback className="text-lg sm:text-xl">
+            {member.nickname.slice(0, 2).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <div className="text-center">
+          <h2 className="flex flex-wrap items-center justify-center gap-1 text-lg font-bold sm:text-xl">
+            {member.nickname}
+            {isOwner ? (
+              <Badge variant="secondary" className="text-xs">
+                방장
+              </Badge>
+            ) : null}
+            {onRest ? (
+              <Badge variant="outline" className="border-blue-200 bg-blue-50 text-xs text-blue-800">
+                휴식
+              </Badge>
+            ) : null}
+          </h2>
+          <div className="mt-1 flex items-center justify-center gap-1 text-xs text-muted-foreground sm:text-sm">
+            <Calendar className="h-3.5 w-3.5 shrink-0 sm:h-4 sm:w-4" aria-hidden />
+            <span>가입 {format(new Date(member.joinedAt), 'yyyy.MM.dd', { locale: ko })}</span>
+          </div>
+        </div>
+      </div>
+
+      {member.bio ? (
+        <div className="rounded-lg border bg-muted/50 p-3">
+          <p className="mb-1 text-sm font-semibold">소개글</p>
+          <p className="whitespace-pre-line break-words text-sm text-muted-foreground">{member.bio}</p>
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3">
+        <div className="flex items-center gap-2 rounded-lg border p-2.5 sm:p-3">
+          <Target className="h-4 w-4 shrink-0 text-blue-500" aria-hidden />
+          <div className="min-w-0">
+            <p className="text-[11px] font-medium text-muted-foreground sm:text-xs">총 운동</p>
+            <p className="text-base font-bold tabular-nums sm:text-lg">{member.totalWorkouts}일</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 rounded-lg border p-2.5 sm:p-3">
+          <Award className="h-4 w-4 shrink-0 text-orange-500" aria-hidden />
+          <div className="min-w-0">
+            <p className="text-[11px] font-medium text-muted-foreground sm:text-xs">이번 주</p>
+            <p className="text-base font-bold tabular-nums sm:text-lg">
+              {member.weeklyWorkouts}/{minWeeklyWorkouts}
+            </p>
+          </div>
+        </div>
+        <div className="col-span-2 flex items-center gap-2 rounded-lg border p-2.5 sm:col-span-1 sm:p-3">
+          <span className="shrink-0 text-red-500" aria-hidden>
+            💰
+          </span>
+          <div className="min-w-0">
+            <p className="text-[11px] font-medium text-muted-foreground sm:text-xs">누적 벌금</p>
+            <p className="text-base font-bold tabular-nums sm:text-lg">
+              {member.totalPenalty.toLocaleString()}원
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {onRest && (() => {
+        const restInfo = member.restInfoList.find((r: RestInfo) => {
+          const start = startOfDay(new Date(r.startDate));
+          const end = endOfDay(new Date(r.endDate));
+          const todayDate = startOfDay(new Date());
+          return todayDate >= start && todayDate <= end;
+        });
+        return (
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-3">
+            <p className="mb-1 font-medium text-blue-800">휴식 중</p>
+            <p className="text-sm text-blue-700">{restInfo?.reason ?? '사유 없음'}</p>
+            {restInfo ? (
+              <p className="mt-1 text-xs text-blue-600">
+                {format(new Date(restInfo.startDate), 'yyyy.MM.dd', { locale: ko })} ~{' '}
+                {format(new Date(restInfo.endDate), 'yyyy.MM.dd', { locale: ko })}
+              </p>
+            ) : null}
+          </div>
+        );
+      })()}
+
+      <div>
+        <h3 className="mb-2 text-sm font-semibold">운동 기록 ({sortedRecords.length}건)</h3>
+        {sortedRecords.length === 0 ? (
+          <p className="text-sm text-muted-foreground">기록이 없습니다.</p>
+        ) : (
+          <ul className="space-y-2 sm:space-y-3">
+            {sortedRecords.map((record) => (
+              <li key={record.id} className="space-y-2 rounded-lg border p-3 text-sm">
+                <div className="flex items-start justify-between gap-2">
+                  <span className="font-medium text-foreground">
+                    {format(new Date(record.workoutDate), 'M/d (EEE)', { locale: ko })}
+                  </span>
+                  <span className="shrink-0 text-xs text-muted-foreground">{record.duration}분</span>
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {record.workoutTypes?.map((type, idx) => (
+                    <Badge key={idx} variant="secondary" className="text-xs">
+                      {type}
+                    </Badge>
+                  ))}
+                </div>
+                {record.imageUrls && record.imageUrls.length > 0 ? (
+                  <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 snap-x snap-mandatory">
+                    {record.imageUrls.map((url, idx) => (
+                      <button
+                        key={idx}
+                        type="button"
+                        aria-label={`${record.workoutDate} 운동 인증 사진 ${idx + 1} 확대`}
+                        className="shrink-0 snap-start overflow-hidden rounded-md border focus:outline-none focus:ring-2 focus:ring-ring active:opacity-90"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onZoomImages(record.imageUrls, idx);
+                        }}
+                      >
+                        <img
+                          src={url}
+                          alt={`운동 인증 사진 ${idx + 1}`}
+                          className="h-20 w-20 object-cover sm:h-16 sm:w-16"
+                        />
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+type MemberListCardProps = {
+  member: RoomMember;
+  ownerNickname: string;
+  minWeeklyWorkouts: number;
+  onSelect: (member: RoomMember) => void;
+};
+
+const MemberListCard = ({ member, ownerNickname, minWeeklyWorkouts, onSelect }: MemberListCardProps) => {
+  const isOwner = member.nickname === ownerNickname;
+  const onRest = member.isOnBreak || isMemberOnRestToday(member);
+
+  const handleClick = () => onSelect(member);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect(member);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={`${member.nickname} 상세 보기`}
+      className="w-full rounded-lg border bg-card p-4 text-left shadow-sm transition-colors active:bg-muted/60 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div className="flex items-start gap-3">
+        <Avatar className="h-11 w-11 shrink-0">
+          <AvatarImage src={member.profileUrl} alt={member.nickname} />
+          <AvatarFallback className="text-sm">{member.nickname.slice(0, 2).toUpperCase()}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate text-base font-semibold">{member.nickname}</span>
+            {isOwner ? (
+              <Badge variant="secondary" className="shrink-0 text-[10px] px-1.5 py-0">
+                방장
+              </Badge>
+            ) : null}
+            {onRest ? (
+              <Badge
+                variant="outline"
+                className="shrink-0 border-blue-200 bg-blue-50 text-[10px] px-1.5 py-0 text-blue-800"
+              >
+                휴식
+              </Badge>
+            ) : null}
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">가입 {formatJoinedDate(member.joinedAt)}</p>
+
+          <div className="mt-3 grid grid-cols-3 gap-2">
+            <div className="rounded-md bg-muted/50 px-2 py-1.5 text-center">
+              <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">이번 주</p>
+              <p className="mt-0.5 text-sm font-semibold tabular-nums">
+                {member.weeklyWorkouts}/{minWeeklyWorkouts}
+              </p>
+            </div>
+            <div className="rounded-md bg-muted/50 px-2 py-1.5 text-center">
+              <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">총 운동</p>
+              <p className="mt-0.5 text-sm font-semibold tabular-nums">{member.totalWorkouts}일</p>
+            </div>
+            <div className="rounded-md bg-muted/50 px-2 py-1.5 text-center">
+              <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">벌금</p>
+              <p className="mt-0.5 text-xs font-semibold leading-tight tabular-nums sm:text-sm">
+                {member.totalPenalty.toLocaleString()}
+                <span className="block text-[10px] font-normal text-muted-foreground">원</span>
+              </p>
+            </div>
+          </div>
+        </div>
+        <ChevronRight className="mt-1 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+      </div>
+    </button>
+  );
+};
+
+export const AdminRoomMembersTab = ({
+  roomId,
+  ownerNickname,
+  minWeeklyWorkouts,
+  members,
+}: AdminRoomMembersTabProps) => {
+  const isMobile = useIsMobile();
+  const [selectedMember, setSelectedMember] = useState<RoomMember | null>(null);
+  const [zoomImageUrls, setZoomImageUrls] = useState<string[] | null>(null);
+  const [zoomImageIndex, setZoomImageIndex] = useState(0);
+  const [carouselApi, setCarouselApi] = useState<CarouselApi>();
+
+  const sortedRecords = useMemo(
+    () => (selectedMember ? sortWorkoutRecords(selectedMember.workoutRecords) : []),
+    [selectedMember],
+  );
+
+  const handleSelectMember = (member: RoomMember) => {
+    setSelectedMember(member);
+  };
+
+  const handleCloseMemberDetail = () => {
+    setSelectedMember(null);
+  };
+
+  const handleZoomImages = (urls: string[], index = 0) => {
+    setZoomImageUrls(urls);
+    setZoomImageIndex(index);
+  };
+
+  useEffect(() => {
+    if (!carouselApi) return;
+
+    const updateIndex = () => {
+      setZoomImageIndex(carouselApi.selectedScrollSnap());
+    };
+
+    updateIndex();
+    carouselApi.on('select', updateIndex);
+
+    return () => {
+      carouselApi.off('select', updateIndex);
+    };
+  }, [carouselApi]);
+
+  const memberDetailContent = selectedMember ? (
+    <MemberDetailContent
+      member={selectedMember}
+      ownerNickname={ownerNickname}
+      minWeeklyWorkouts={minWeeklyWorkouts}
+      sortedRecords={sortedRecords}
+      onZoomImages={handleZoomImages}
+    />
+  ) : null;
+
+  return (
+    <div className="space-y-4 md:space-y-6">
+      <Card className="border-0 shadow-none sm:border sm:shadow-sm">
+        <CardHeader className="px-0 pb-3 pt-0 sm:px-6 sm:pt-6">
+          <CardTitle className="text-lg sm:text-xl">참여 멤버</CardTitle>
+          <CardDescription className="text-xs sm:text-sm">
+            {members.length}명 · 탭하여 운동 기록과 상세 정보 확인
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="px-0 sm:px-6 sm:pb-6">
+          {members.length === 0 ? (
+            <AdminStateBlock variant="empty" description="참여 중인 멤버가 없습니다." />
+          ) : (
+            <>
+              {/* 모바일: 카드 리스트 */}
+              <div className="space-y-2 md:hidden">
+                {members.map((member) => (
+                  <MemberListCard
+                    key={member.id}
+                    member={member}
+                    ownerNickname={ownerNickname}
+                    minWeeklyWorkouts={minWeeklyWorkouts}
+                    onSelect={handleSelectMember}
+                  />
+                ))}
+              </div>
+
+              {/* 데스크톱: 테이블 */}
+              <div className="hidden overflow-x-auto rounded-md border md:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>멤버</TableHead>
+                      <TableHead>가입일</TableHead>
+                      <TableHead>이번 주</TableHead>
+                      <TableHead>총 운동</TableHead>
+                      <TableHead>누적 벌금</TableHead>
+                      <TableHead>휴식</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {members.map((member) => {
+                      const isOwner = member.nickname === ownerNickname;
+                      const onRest = member.isOnBreak || isMemberOnRestToday(member);
+
+                      return (
+                        <TableRow
+                          key={member.id}
+                          role="button"
+                          tabIndex={0}
+                          aria-label={`${member.nickname} 상세 보기`}
+                          className="cursor-pointer hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-inset"
+                          onClick={() => handleSelectMember(member)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              handleSelectMember(member);
+                            }
+                          }}
+                        >
+                          <TableCell>
+                            <div className="flex min-w-0 items-center gap-2">
+                              <Avatar className="h-8 w-8 shrink-0">
+                                <AvatarImage src={member.profileUrl} alt={member.nickname} />
+                                <AvatarFallback className="text-xs">
+                                  {member.nickname.slice(0, 2).toUpperCase()}
+                                </AvatarFallback>
+                              </Avatar>
+                              <div className="min-w-0">
+                                <div className="flex flex-wrap items-center gap-1">
+                                  <span className="truncate font-medium">{member.nickname}</span>
+                                  {isOwner ? (
+                                    <Badge variant="secondary" className="shrink-0 text-xs">
+                                      방장
+                                    </Badge>
+                                  ) : null}
+                                </div>
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {formatJoinedDate(member.joinedAt)}
+                          </TableCell>
+                          <TableCell>
+                            {member.weeklyWorkouts} / {minWeeklyWorkouts}회
+                          </TableCell>
+                          <TableCell>{member.totalWorkouts}일</TableCell>
+                          <TableCell className="font-medium tabular-nums">
+                            {member.totalPenalty.toLocaleString()}원
+                          </TableCell>
+                          <TableCell>
+                            {onRest ? (
+                              <Badge
+                                variant="outline"
+                                className="border-blue-200 bg-blue-50 text-blue-800"
+                              >
+                                휴식
+                              </Badge>
+                            ) : (
+                              <span className="text-sm text-muted-foreground">-</span>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <PenaltyOverview roomId={roomId} roomMembers={members} currentUserId={0} />
+
+      {/* 모바일: 하단 시트 */}
+      {isMobile ? (
+        <Sheet open={!!selectedMember} onOpenChange={(open) => !open && handleCloseMemberDetail()}>
+          <SheetContent
+            side="bottom"
+            className="flex h-[92dvh] flex-col rounded-t-2xl p-0"
+            aria-labelledby="admin-member-sheet-title"
+          >
+            <SheetHeader className="shrink-0 border-b px-4 pb-3 pt-4 text-left">
+              <SheetTitle id="admin-member-sheet-title" className="text-base">
+                멤버 상세
+              </SheetTitle>
+            </SheetHeader>
+            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-6">
+              {memberDetailContent}
+            </div>
+          </SheetContent>
+        </Sheet>
+      ) : (
+        <Dialog open={!!selectedMember} onOpenChange={(open) => !open && handleCloseMemberDetail()}>
+          <DialogContent
+            className="max-h-[90vh] max-w-lg overflow-y-auto"
+            aria-labelledby="admin-member-profile-title"
+          >
+            <DialogHeader>
+              <DialogTitle id="admin-member-profile-title">멤버 상세</DialogTitle>
+            </DialogHeader>
+            {memberDetailContent}
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* 인증 사진 확대 */}
+      <Dialog open={!!zoomImageUrls} onOpenChange={() => setZoomImageUrls(null)}>
+        <DialogContent
+          className={cn(
+            'border-0 bg-black/95 p-0 shadow-none',
+            'fixed inset-0 left-0 top-0 z-50 flex h-[100dvh] w-full max-w-none translate-x-0 translate-y-0 flex-col items-center justify-center',
+            'data-[state=open]:slide-in-from-bottom-0 data-[state=closed]:slide-out-to-bottom-0',
+            'sm:inset-auto sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[90vh] sm:max-w-4xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:border sm:bg-background sm:p-0 sm:shadow-lg',
+          )}
+        >
+          {zoomImageUrls && zoomImageUrls.length > 0 ? (
+            <div className="relative flex h-full w-full items-center justify-center sm:min-h-[200px]">
+              {zoomImageUrls.length === 1 ? (
+                <img
+                  src={zoomImageUrls[0]}
+                  alt="확대된 운동 인증 사진"
+                  className="max-h-[85dvh] w-full object-contain p-2 sm:max-h-[90vh] sm:rounded"
+                />
+              ) : (
+                <Carousel
+                  className="w-full px-12"
+                  setApi={setCarouselApi}
+                  opts={{
+                    startIndex: zoomImageIndex,
+                    loop: true,
+                  }}
+                >
+                  <CarouselContent>
+                    {zoomImageUrls.map((url, idx) => (
+                      <CarouselItem key={idx}>
+                        <img
+                          src={url}
+                          alt={`확대된 운동 인증 사진 ${idx + 1}`}
+                          className="max-h-[85dvh] w-full object-contain sm:max-h-[90vh] sm:rounded"
+                        />
+                      </CarouselItem>
+                    ))}
+                  </CarouselContent>
+                  <CarouselPrevious className="left-2 h-11 w-11 border-0 bg-black/40 text-white hover:bg-black/60 sm:left-4" />
+                  <CarouselNext className="right-2 h-11 w-11 border-0 bg-black/40 text-white hover:bg-black/60 sm:right-4" />
+                </Carousel>
+              )}
+              {zoomImageUrls.length > 1 ? (
+                <div className="absolute bottom-6 left-1/2 -translate-x-1/2 rounded-full bg-black/60 px-4 py-1.5 text-sm text-white sm:bottom-4">
+                  {zoomImageIndex + 1} / {zoomImageUrls.length}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default AdminRoomMembersTab;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -478,6 +478,27 @@ class ApiClient {
       method: "DELETE",
     });
   }
+
+  /**
+   * GET /admin/workout/rooms/{roomId}/messages
+   * 운동방 채팅 내역 조회 (관리자 읽기 전용).
+   * @param roomId - 방 ID
+   * @param cursorId - 더 오래된 메시지 조회용 커서
+   * @param size - 페이지 크기 (기본 20)
+   */
+  async getAdminChatHistory(
+    roomId: number,
+    cursorId?: number | null,
+    size = 20
+  ): Promise<ChatHistoryResponse> {
+    const params = new URLSearchParams({ size: String(size) });
+    if (cursorId != null) {
+      params.set("cursorId", String(cursorId));
+    }
+    return this.request<ChatHistoryResponse>(
+      `/admin/workout/rooms/${roomId}/messages?${params.toString()}`
+    );
+  }
 }
 
 export const api = new ApiClient();

--- a/src/pages/admin/AdminMembersPage.tsx
+++ b/src/pages/admin/AdminMembersPage.tsx
@@ -185,16 +185,16 @@ const AdminMembersPage = () => {
   return (
     <Layout>
       <div className="space-y-6">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h1 className="text-2xl font-bold">회원 관리</h1>
-            <p className="text-muted-foreground mt-1">회원 목록 검색 및 역할 변경</p>
+            <h1 className="text-xl font-bold md:text-2xl">회원 관리</h1>
+            <p className="mt-1 text-sm text-muted-foreground md:text-base">회원 목록 검색 및 역할 변경</p>
           </div>
           <Button
             variant="outline"
             onClick={() => membersQuery.refetch()}
             disabled={membersQuery.isFetching}
-            className="gap-2"
+            className="w-full gap-2 sm:w-auto"
           >
             <RefreshCcw className={cn('h-4 w-4', membersQuery.isFetching && 'animate-spin')} />
             새로고침
@@ -202,7 +202,7 @@ const AdminMembersPage = () => {
         </div>
 
         <div className="rounded-lg border bg-background p-4">
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="relative w-full md:max-w-md">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
@@ -213,11 +213,10 @@ const AdminMembersPage = () => {
               />
             </div>
 
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">Role</span>
+            <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="flex min-w-0 flex-1 items-center gap-2">
                 <Select value={roleFilter} onValueChange={(v) => setRoleFilter(v as 'ALL' | Role)}>
-                  <SelectTrigger className="w-[160px]">
+                  <SelectTrigger className="w-full sm:w-[160px]">
                     <SelectValue placeholder="전체" />
                   </SelectTrigger>
                   <SelectContent>
@@ -230,10 +229,9 @@ const AdminMembersPage = () => {
                 </Select>
               </div>
 
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-muted-foreground">Size</span>
+              <div className="flex min-w-0 flex-1 items-center gap-2">
                 <Select value={String(size)} onValueChange={(v) => setSize(Number(v))}>
-                  <SelectTrigger className="w-[120px]">
+                  <SelectTrigger className="w-full sm:w-[120px]">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -262,7 +260,7 @@ const AdminMembersPage = () => {
               <AdminStateBlock variant="empty" description="검색 결과가 없습니다." />
             ) : (
               <div className="space-y-3">
-                <div className="flex items-center justify-between text-sm text-muted-foreground">
+                <div className="flex flex-col items-start justify-between gap-2 text-sm text-muted-foreground sm:flex-row sm:items-center">
                   <div>
                     페이지 <span className="text-foreground">{currentPage + 1}</span>
                     {totalPages ? (
@@ -275,77 +273,156 @@ const AdminMembersPage = () => {
                   {membersQuery.isFetching ? <div>업데이트 중...</div> : null}
                 </div>
 
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-[80px]">ID</TableHead>
-                      <TableHead>이메일</TableHead>
-                      <TableHead>닉네임</TableHead>
-                      <TableHead className="w-[220px]">역할</TableHead>
-                      <TableHead className="w-[120px] text-right">운동일수</TableHead>
-                      <TableHead className="w-[140px] text-right">누적 벌금</TableHead>
-                      <TableHead className="w-[140px]">가입일</TableHead>
-                      <TableHead className="w-[100px] text-right">작업</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {content.map((m) => {
-                      const isMe = currentMember?.id === m.id;
-                      const isUpdatingThisRow = roleMutation.isPending && updatingMemberId === m.id;
-                      const isDeletingThisRow = deleteMutation.isPending && pendingDelete.target?.id === m.id;
-                      return (
-                        <TableRow key={m.id}>
-                          <TableCell className="font-mono text-xs text-muted-foreground">{m.id}</TableCell>
-                          <TableCell className="truncate">{m.email}</TableCell>
-                          <TableCell className="flex items-center gap-2">
-                            <span className="truncate font-medium">{m.nickname}</span>
+                {/* 모바일: 카드 리스트 */}
+                <div className="space-y-3 md:hidden">
+                  {content.map((m) => {
+                    const isMe = currentMember?.id === m.id;
+                    const isUpdatingThisRow = roleMutation.isPending && updatingMemberId === m.id;
+                    const isDeletingThisRow = deleteMutation.isPending && pendingDelete.target?.id === m.id;
+
+                    return (
+                      <div key={m.id} className="rounded-lg border bg-card p-4 shadow-sm">
+                        <div className="min-w-0 space-y-1">
+                          <div className="text-xs font-mono text-muted-foreground">#{m.id}</div>
+                          <div className="flex items-center gap-2">
+                            <span className="truncate text-base font-semibold text-foreground">{m.nickname}</span>
                             {isMe ? (
                               <Badge variant="secondary" className="shrink-0">
                                 ME
                               </Badge>
                             ) : null}
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex items-center gap-2">
-                              <Select value={m.role} onValueChange={(v) => openConfirm(m, v as Role)} disabled={isUpdatingThisRow || isDeletingThisRow}>
-                                <SelectTrigger className="w-[160px]">
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {(Object.keys(ROLE_LABEL) as Role[]).map((r) => (
-                                    <SelectItem key={r} value={r}>
-                                      {ROLE_LABEL[r]}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                              {isUpdatingThisRow ? <span className="text-xs text-muted-foreground">변경 중...</span> : null}
-                            </div>
-                          </TableCell>
-                          <TableCell className="text-right tabular-nums">{m.totalWorkoutDays ?? 0}</TableCell>
-                          <TableCell className="text-right tabular-nums">{(m.totalPenalty ?? 0).toLocaleString()}</TableCell>
-                          <TableCell className="text-sm text-muted-foreground">{formatDate(m.createdAt)}</TableCell>
-                          <TableCell className="text-right">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => openDeleteConfirm(m)}
-                              disabled={isDeletingThisRow || isUpdatingThisRow}
-                              className="gap-1"
+                          </div>
+                          <div className="truncate text-xs text-muted-foreground">{m.email}</div>
+                        </div>
+
+                        <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-muted-foreground">
+                          <div className="space-y-0.5">
+                            <div className="text-[11px] font-medium uppercase tracking-wide text-foreground/70">운동일수</div>
+                            <div className="tabular-nums text-sm text-foreground">{m.totalWorkoutDays ?? 0}</div>
+                          </div>
+                          <div className="space-y-0.5">
+                            <div className="text-[11px] font-medium uppercase tracking-wide text-foreground/70">누적 벌금</div>
+                            <div className="tabular-nums text-sm text-foreground">{(m.totalPenalty ?? 0).toLocaleString()}원</div>
+                          </div>
+                          <div className="col-span-2 space-y-0.5">
+                            <div className="text-[11px] font-medium uppercase tracking-wide text-foreground/70">가입일</div>
+                            <div className="text-sm text-foreground">{formatDate(m.createdAt)}</div>
+                          </div>
+                        </div>
+
+                        <div className="mt-4 space-y-2">
+                          <div className="flex items-center gap-2">
+                            <Select
+                              value={m.role}
+                              onValueChange={(v) => openConfirm(m, v as Role)}
+                              disabled={isUpdatingThisRow || isDeletingThisRow}
                             >
-                              <Trash2 className="h-3 w-3" />
-                              {isDeletingThisRow ? '삭제 중...' : '삭제'}
-                            </Button>
-                          </TableCell>
+                              <SelectTrigger className="w-full">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {(Object.keys(ROLE_LABEL) as Role[]).map((r) => (
+                                  <SelectItem key={r} value={r}>
+                                    {ROLE_LABEL[r]}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          {isUpdatingThisRow ? <span className="text-xs text-muted-foreground">변경 중...</span> : null}
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openDeleteConfirm(m)}
+                            disabled={isDeletingThisRow || isUpdatingThisRow}
+                            className="w-full gap-1"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                            {isDeletingThisRow ? '삭제 중...' : '삭제'}
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {/* 데스크톱: 테이블 */}
+                <div className="hidden md:block">
+                  <div className="overflow-x-auto">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead className="w-[80px]">ID</TableHead>
+                          <TableHead>이메일</TableHead>
+                          <TableHead>닉네임</TableHead>
+                          <TableHead className="w-[220px]">역할</TableHead>
+                          <TableHead className="w-[120px] text-right">운동일수</TableHead>
+                          <TableHead className="w-[140px] text-right">누적 벌금</TableHead>
+                          <TableHead className="w-[140px]">가입일</TableHead>
+                          <TableHead className="w-[100px] text-right">작업</TableHead>
                         </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
+                      </TableHeader>
+                      <TableBody>
+                        {content.map((m) => {
+                          const isMe = currentMember?.id === m.id;
+                          const isUpdatingThisRow = roleMutation.isPending && updatingMemberId === m.id;
+                          const isDeletingThisRow = deleteMutation.isPending && pendingDelete.target?.id === m.id;
+                          return (
+                            <TableRow key={m.id}>
+                              <TableCell className="font-mono text-xs text-muted-foreground">{m.id}</TableCell>
+                              <TableCell className="truncate">{m.email}</TableCell>
+                              <TableCell className="flex items-center gap-2">
+                                <span className="truncate font-medium">{m.nickname}</span>
+                                {isMe ? (
+                                  <Badge variant="secondary" className="shrink-0">
+                                    ME
+                                  </Badge>
+                                ) : null}
+                              </TableCell>
+                              <TableCell>
+                                <div className="flex items-center gap-2">
+                                  <Select value={m.role} onValueChange={(v) => openConfirm(m, v as Role)} disabled={isUpdatingThisRow || isDeletingThisRow}>
+                                    <SelectTrigger className="w-[160px]">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {(Object.keys(ROLE_LABEL) as Role[]).map((r) => (
+                                        <SelectItem key={r} value={r}>
+                                          {ROLE_LABEL[r]}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                  {isUpdatingThisRow ? <span className="text-xs text-muted-foreground">변경 중...</span> : null}
+                                </div>
+                              </TableCell>
+                              <TableCell className="text-right tabular-nums">{m.totalWorkoutDays ?? 0}</TableCell>
+                              <TableCell className="text-right tabular-nums">{(m.totalPenalty ?? 0).toLocaleString()}</TableCell>
+                              <TableCell className="text-sm text-muted-foreground">{formatDate(m.createdAt)}</TableCell>
+                              <TableCell className="text-right">
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => openDeleteConfirm(m)}
+                                  disabled={isDeletingThisRow || isUpdatingThisRow}
+                                  className="gap-1"
+                                >
+                                  <Trash2 className="h-3 w-3" />
+                                  {isDeletingThisRow ? '삭제 중...' : '삭제'}
+                                </Button>
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
 
                 {totalPages > 1 ? (
-                  <Pagination>
-                    <PaginationContent>
+                  <div className="-mx-4 overflow-x-auto px-4 md:mx-0 md:overflow-visible md:px-0">
+                    <Pagination>
+                      <PaginationContent className="flex-nowrap">
                       <PaginationItem>
                         <PaginationPrevious
                           href="#"
@@ -390,8 +467,9 @@ const AdminMembersPage = () => {
                           className={cn(isLast && 'pointer-events-none opacity-50')}
                         />
                       </PaginationItem>
-                    </PaginationContent>
-                  </Pagination>
+                      </PaginationContent>
+                    </Pagination>
+                  </div>
                 ) : null}
               </div>
             )}
@@ -405,7 +483,7 @@ const AdminMembersPage = () => {
             <AlertDialogTitle>역할을 변경할까요?</AlertDialogTitle>
             <AlertDialogDescription>
               {pendingChange.target ? (
-                <div className="space-y-1">
+                <div className="min-w-0 space-y-1 break-words">
                   <div>
                     대상: <span className="font-medium text-foreground">{pendingChange.target.nickname}</span> ({pendingChange.target.email})
                   </div>
@@ -437,7 +515,7 @@ const AdminMembersPage = () => {
             <AlertDialogTitle>회원을 삭제할까요?</AlertDialogTitle>
             <AlertDialogDescription>
               {pendingDelete.target ? (
-                <div className="space-y-2">
+                <div className="min-w-0 space-y-2 break-words">
                   <div>
                     대상: <span className="font-medium text-foreground">{pendingDelete.target.nickname}</span> ({pendingDelete.target.email})
                   </div>

--- a/src/pages/admin/AdminRoomDetailPage.tsx
+++ b/src/pages/admin/AdminRoomDetailPage.tsx
@@ -95,9 +95,9 @@ const AdminRoomDetailPage = () => {
               <ArrowLeft className="h-4 w-4" />
             </Link>
           </Button>
-          <div>
+          <div className="min-w-0 flex-1">
             <h1 className="text-xl font-bold md:text-2xl">운동방 상세</h1>
-            <p className="mt-1 text-xs text-muted-foreground md:text-sm">
+            <p className="mt-1 break-words text-xs text-muted-foreground md:text-sm">
               {Number.isFinite(numericRoomId) ? `ID: ${numericRoomId}` : '유효하지 않은 ID'}
               {room?.name ? ` · ${room.name}` : ''}
             </p>
@@ -119,10 +119,10 @@ const AdminRoomDetailPage = () => {
           <Tabs defaultValue="settings">
             <TabsList className="flex w-full gap-1 sm:inline-flex">
               <TabsTrigger value="settings" className="flex-1">
-                Settings
+                설정
               </TabsTrigger>
               <TabsTrigger value="members" className="flex-1">
-                Members
+                멤버
               </TabsTrigger>
             </TabsList>
 
@@ -132,7 +132,7 @@ const AdminRoomDetailPage = () => {
                   <CardTitle>규칙 설정</CardTitle>
                   <CardDescription>정원 / 주간 목표 / 벌금 규칙을 수정합니다.</CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-6">
+                <CardContent className="space-y-6 p-4 sm:p-6">
                   <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                     <div className="space-y-2">
                       <Label htmlFor="admin-max-members" className="text-xs md:text-sm">

--- a/src/pages/admin/AdminRoomDetailPage.tsx
+++ b/src/pages/admin/AdminRoomDetailPage.tsx
@@ -13,6 +13,7 @@ import { validateWorkoutRoomRules } from '@/lib/workoutRoomRules';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import { AdminStateBlock } from '@/components/admin/AdminStateBlock';
+import { AdminRoomMembersTab } from '@/components/admin/AdminRoomMembersTab';
 
 const AdminRoomDetailPage = () => {
   const { roomId } = useParams();
@@ -28,6 +29,7 @@ const AdminRoomDetailPage = () => {
   });
 
   const room = detailQuery.data?.workoutRoomInfo ?? null;
+  const members = detailQuery.data?.workoutRoomMembers ?? [];
 
   const [initialized, setInitialized] = useState(false);
   const [maxMembers, setMaxMembers] = useState('10');
@@ -223,7 +225,12 @@ const AdminRoomDetailPage = () => {
             </TabsContent>
 
             <TabsContent value="members" className="mt-3 md:mt-4">
-              <AdminStateBlock description="Members 탭은 추후 구현 예정입니다." />
+              <AdminRoomMembersTab
+                roomId={numericRoomId}
+                ownerNickname={room.ownerNickname}
+                minWeeklyWorkouts={room.minWeeklyWorkouts}
+                members={members}
+              />
             </TabsContent>
           </Tabs>
         )}

--- a/src/pages/admin/AdminRoomDetailPage.tsx
+++ b/src/pages/admin/AdminRoomDetailPage.tsx
@@ -14,6 +14,7 @@ import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tansta
 import { useEffect, useMemo, useState } from 'react';
 import { AdminStateBlock } from '@/components/admin/AdminStateBlock';
 import { AdminRoomMembersTab } from '@/components/admin/AdminRoomMembersTab';
+import { AdminRoomChatTab } from '@/components/admin/AdminRoomChatTab';
 
 const AdminRoomDetailPage = () => {
   const { roomId } = useParams();
@@ -36,11 +37,13 @@ const AdminRoomDetailPage = () => {
   const [minWeeklyWorkouts, setMinWeeklyWorkouts] = useState('3');
   const [penaltyPerMiss, setPenaltyPerMiss] = useState('5000');
   const [localError, setLocalError] = useState('');
+  const [activeTab, setActiveTab] = useState('settings');
 
   // When navigating between room IDs without unmount, reset initialization.
   useEffect(() => {
     setInitialized(false);
     setLocalError('');
+    setActiveTab('settings');
   }, [numericRoomId]);
 
   const hydrateFromRoom = (r: typeof room) => {
@@ -118,13 +121,16 @@ const AdminRoomDetailPage = () => {
         ) : !room ? (
           <AdminStateBlock variant="empty" description="운동방 정보가 없습니다." />
         ) : (
-          <Tabs defaultValue="settings">
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
             <TabsList className="flex w-full gap-1 sm:inline-flex">
               <TabsTrigger value="settings" className="flex-1">
                 설정
               </TabsTrigger>
               <TabsTrigger value="members" className="flex-1">
                 멤버
+              </TabsTrigger>
+              <TabsTrigger value="chat" className="flex-1">
+                채팅
               </TabsTrigger>
             </TabsList>
 
@@ -230,6 +236,14 @@ const AdminRoomDetailPage = () => {
                 ownerNickname={room.ownerNickname}
                 minWeeklyWorkouts={room.minWeeklyWorkouts}
                 members={members}
+              />
+            </TabsContent>
+
+            <TabsContent value="chat" className="mt-3 md:mt-4">
+              <AdminRoomChatTab
+                roomId={numericRoomId}
+                members={members}
+                active={activeTab === 'chat'}
               />
             </TabsContent>
           </Tabs>

--- a/src/pages/admin/AdminRoomsPage.tsx
+++ b/src/pages/admin/AdminRoomsPage.tsx
@@ -167,7 +167,6 @@ const AdminRoomsPage = () => {
 
             <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
               <div className="flex min-w-0 flex-1 items-center gap-2">
-                <span className="whitespace-normal text-sm text-muted-foreground">상태</span>
                 <Select value={activeFilter} onValueChange={(v) => setActiveFilter(v as ActiveFilter)}>
                   <SelectTrigger className="w-full sm:w-[160px]">
                     <SelectValue placeholder="전체" />
@@ -181,7 +180,6 @@ const AdminRoomsPage = () => {
               </div>
 
               <div className="flex min-w-0 flex-1 items-center gap-2">
-                <span className="whitespace-normal text-sm text-muted-foreground">Size</span>
                 <Select value={String(size)} onValueChange={(v) => setSize(Number(v))}>
                   <SelectTrigger className="w-full sm:w-[120px]">
                     <SelectValue />
@@ -277,7 +275,7 @@ const AdminRoomsPage = () => {
                             size="sm"
                             onClick={() => openDeleteConfirm(r)}
                             disabled={isDeletingThisRow}
-                            className="gap-1"
+                            className="flex-1 gap-1"
                           >
                             <Trash2 className="h-3 w-3" />
                             {isDeletingThisRow ? '삭제 중...' : '삭제'}
@@ -350,8 +348,9 @@ const AdminRoomsPage = () => {
                 </div>
 
                 {totalPages > 1 ? (
-                  <Pagination>
-                    <PaginationContent>
+                  <div className="-mx-4 overflow-x-auto px-4 md:mx-0 md:overflow-visible md:px-0">
+                    <Pagination>
+                      <PaginationContent className="flex-nowrap">
                       <PaginationItem>
                         <PaginationPrevious
                           href="#"
@@ -396,8 +395,9 @@ const AdminRoomsPage = () => {
                           className={cn(isLast && 'pointer-events-none opacity-50')}
                         />
                       </PaginationItem>
-                    </PaginationContent>
-                  </Pagination>
+                      </PaginationContent>
+                    </Pagination>
+                  </div>
                 ) : null}
               </div>
             )}
@@ -411,7 +411,7 @@ const AdminRoomsPage = () => {
             <AlertDialogTitle>운동방을 삭제할까요?</AlertDialogTitle>
             <AlertDialogDescription>
               {pendingDelete.target ? (
-                <div className="space-y-2">
+                <div className="min-w-0 space-y-2 break-words">
                   <div>
                     대상: <span className="font-medium text-foreground">{pendingDelete.target.name}</span> (ID: {pendingDelete.target.id})
                   </div>


### PR DESCRIPTION
Closes #123

## Description

### 관리자 운동방 채팅 탭
- `AdminRoomChatTab` 읽기 전용 채팅 내역 UI 추가
- `getAdminChatHistory` API 연동 및 커서 페이지네이션
- 백엔드 API 스펙 문서 (`docs/admin-room-chat-backend.md`) 추가

### 관리자 운동방 멤버 탭
- `AdminRoomMembersTab`으로 멤버 관리 UI 분리·강화
- `AdminRoomDetailPage`에 채팅/멤버 탭 통합

### 기타
- 관리자 페이지 레이아웃·스타일 개선
- FAQ 솔로 운동 문의 항목 추가
- 미사용 Google Ads 스크립트 제거