### PR TITLE
운동방 벌금제도 선택제 및 ON/OFF 예약 전환 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,9 @@
         "@eslint/js": "^9.9.0",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/typography": "^0.5.15",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -74,14 +77,23 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
         "globals": "^15.9.0",
+        "jsdom": "^25.0.1",
         "lovable-tagger": "^1.1.7",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.11",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1",
-        "vite-plugin-pwa": "^1.1.0"
+        "vite-plugin-pwa": "^1.1.0",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -93,6 +105,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -126,6 +152,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1685,6 +1712,123 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
@@ -2355,6 +2499,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.6.tgz",
       "integrity": "sha512-4uyt8BOrBsSq6i4yiOV/gG6BnnrvTeyymlNcaN/dKvyU1GoolxAafvIvaNP1RCGPlNab3OuE4MKUQuv2lH+PLQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -2421,6 +2566,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.6.tgz",
       "integrity": "sha512-YYGARbutghQY4zZUWMYia0ib0Y/rb52y72/N0z3vglRHL7ii/AaK9SA7S/dzScVOlCdnbHXz+sc5Dq+r8fwFAg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.6",
         "@firebase/component": "0.7.0",
@@ -2436,7 +2582,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.6.1",
@@ -2887,6 +3034,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3483,9 +3631,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -5361,6 +5509,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stomp/stompjs": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.1.1.tgz",
@@ -5668,6 +5823,114 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -5731,6 +5994,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5767,6 +6037,7 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5778,6 +6049,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5842,6 +6114,7 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -6059,6 +6332,7 @@
       "integrity": "sha512-MCbrb508JZHqe7bUibmZj/lyojdhLRnfkmyXnkrCM2zVrjTgL89U8UEfInpKTvPeTnxsw2hmyZxnhsdNR6yhwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cac": "^6.7.14",
         "colorette": "^2.0.20",
@@ -6091,12 +6365,99 @@
         "vite": "^4 || ^5 || ^6 || ^7.0.0-beta.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6112,6 +6473,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -6202,6 +6573,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -6239,6 +6620,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -6462,6 +6853,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6581,6 +6973,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -6887,6 +7289,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -6898,6 +7307,27 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -7026,6 +7456,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -7085,6 +7566,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -7107,6 +7589,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -7212,6 +7701,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7238,6 +7737,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -7297,7 +7803,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -7326,6 +7833,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -7413,6 +7933,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -7529,6 +8056,7 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7722,6 +8250,16 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -8440,11 +8978,52 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ico-endec": {
       "version": "0.1.6",
@@ -8452,6 +9031,19 @@
       "integrity": "sha512-ZdLU38ZoED3g1j3iEyzcQj+wAkY2xfWNkymszfJPoxucIUhK7NayQ+/C4Kv0nDFMIsbtbEHldv3V8PU494/ueQ==",
       "dev": true,
       "license": "MPL-2.0"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/idb": {
       "version": "7.1.1",
@@ -8494,6 +9086,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -8836,6 +9438,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9076,6 +9685,84 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -9321,14 +10008,24 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -9381,6 +10078,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -9483,6 +10190,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9543,6 +10257,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/once": {
@@ -9642,6 +10370,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9692,6 +10433,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9758,6 +10506,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9919,6 +10668,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10034,6 +10828,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10060,6 +10855,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10073,6 +10869,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
       "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -10285,6 +11082,20 @@
         "decimal.js-light": "^2.4.1"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10492,6 +11303,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10588,6 +11406,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -10820,6 +11658,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10936,6 +11781,20 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11161,6 +12020,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -11221,6 +12093,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
@@ -11236,6 +12115,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11325,6 +12205,7 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -11372,6 +12253,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -11413,12 +12311,43 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-data-view": {
       "version": "1.1.0",
@@ -11437,6 +12366,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -11584,6 +12526,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11909,6 +12852,7 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -12424,6 +13368,244 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
@@ -12458,6 +13640,30 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -12574,6 +13780,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -12743,6 +13966,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12819,6 +14043,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -13060,6 +14285,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "dev": "vite --port 3000",
     "build": "vite build",
     "lint": "eslint --quiet ./src",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -66,6 +68,9 @@
     "@eslint/js": "^9.9.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/typography": "^0.5.15",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -76,12 +81,14 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
+    "jsdom": "^25.0.1",
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vite-plugin-pwa": "^1.1.0"
+    "vite-plugin-pwa": "^1.1.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/components/AvailableWorkoutRooms.tsx
+++ b/src/components/AvailableWorkoutRooms.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { LogIn, Plus, Trophy, Users } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { formatPenaltyPerMiss } from '@/lib/workoutRoomRules';
 import { WorkoutRoom } from '@/types';
 
 interface AvailableWorkoutRoomsProps {
@@ -42,7 +43,7 @@ export const AvailableWorkoutRooms = ({ workoutRooms, onCreateWorkoutRoom, onJoi
                 {workoutRoom.name}
               </CardTitle>
               <CardDescription>
-                주 {workoutRoom.minWeeklyWorkouts}회 • 벌금 {workoutRoom.penaltyPerMiss.toLocaleString()}원
+                주 {workoutRoom.minWeeklyWorkouts}회 • {formatPenaltyPerMiss(workoutRoom.penaltyPerMiss)}
               </CardDescription>
             </CardHeader>
             <CardContent className="flex-grow">

--- a/src/components/MyWorkoutRoom.tsx
+++ b/src/components/MyWorkoutRoom.tsx
@@ -7,11 +7,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/
 import { Calendar } from "./ui/calendar";
 import MemberStatus from "./MemberStatus";
 import { RoomCodeSection } from "./RoomCodeSection";
+import { PenaltySettingsSection } from "./PenaltySettingsSection";
 import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious, type CarouselApi } from "./ui/carousel";
 import { Dialog, DialogContent } from "./ui/dialog";
 import { Clock } from "lucide-react";
 
-export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRegenerateEntryCode, isRegeneratingEntryCode }) => {
+export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRegenerateEntryCode, isRegeneratingEntryCode, onOpenPenaltySchedule }) => {
     const [date, setDate] = useState<Date | undefined>(new Date());
     const [zoomImageUrls, setZoomImageUrls] = useState<string[] | null>(null);
     const [zoomImageIndex, setZoomImageIndex] = useState<number>(0);
@@ -232,14 +233,32 @@ export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRege
             </CardContent>
           </Card>
         )}
+        {currentWorkoutRoom.workoutRoomInfo && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">💰 벌금제도</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <PenaltySettingsSection
+                penaltyEnabled={currentWorkoutRoom.workoutRoomInfo.penaltyEnabled}
+                penaltyPerMiss={currentWorkoutRoom.workoutRoomInfo.penaltyPerMiss}
+                pendingPenaltyEnabled={currentWorkoutRoom.workoutRoomInfo.pendingPenaltyEnabled}
+                pendingPenaltyPerMiss={currentWorkoutRoom.workoutRoomInfo.pendingPenaltyPerMiss}
+                penaltyChangeEffectiveDate={currentWorkoutRoom.workoutRoomInfo.penaltyChangeEffectiveDate}
+                isOwner={isOwner}
+                onOpenSchedule={onOpenPenaltySchedule}
+              />
+            </CardContent>
+          </Card>
+        )}
         <MemberStatus currentWorkoutRoom={currentWorkoutRoom} today={today} />
         <Card>
           <CardHeader>
             <CardTitle className="text-xl font-bold">📅 월별 운동 현황</CardTitle>
-            <CardDescription className='p-2'>
+            <div className="text-sm text-muted-foreground p-2">
               <div>
                 달력에서 날짜를 선택하여
-              </div>   
+              </div>
               <div>
                 멤버별 운동 상태를 확인하세요.
               </div>
@@ -253,7 +272,7 @@ export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRege
                   <span className="text-gray-600">다른 멤버 활동</span>
                 </div>
               </div>
-            </CardDescription>
+            </div>
           </CardHeader>
           <CardContent className="flex justify-center">
             <Calendar

--- a/src/components/MyWorkoutRoom.tsx
+++ b/src/components/MyWorkoutRoom.tsx
@@ -236,7 +236,7 @@ export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRege
         {currentWorkoutRoom.workoutRoomInfo && (
           <Card>
             <CardHeader>
-              <CardTitle className="text-lg">💰 벌금제도</CardTitle>
+              <CardTitle className="text-lg">💰 운동방 운영 방식</CardTitle>
             </CardHeader>
             <CardContent>
               <PenaltySettingsSection

--- a/src/components/PenaltySettingsSection.tsx
+++ b/src/components/PenaltySettingsSection.tsx
@@ -1,0 +1,51 @@
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+interface PenaltySettingsSectionProps {
+  penaltyEnabled: boolean;
+  penaltyPerMiss: number | null;
+  pendingPenaltyEnabled?: boolean | null;
+  pendingPenaltyPerMiss?: number | null;
+  penaltyChangeEffectiveDate?: string | null;
+  isOwner: boolean;
+  onOpenSchedule: () => void;
+}
+
+export const PenaltySettingsSection = ({
+  penaltyEnabled,
+  penaltyPerMiss,
+  pendingPenaltyEnabled,
+  pendingPenaltyPerMiss,
+  penaltyChangeEffectiveDate,
+  isOwner,
+  onOpenSchedule,
+}: PenaltySettingsSectionProps) => {
+  const hasPendingChange = pendingPenaltyEnabled !== null && pendingPenaltyEnabled !== undefined;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Badge variant={penaltyEnabled ? 'default' : 'outline'}>
+          {penaltyEnabled ? `벌금제도 사용 중 (회당 ${penaltyPerMiss?.toLocaleString()}원)` : '벌금제도 미사용'}
+        </Badge>
+      </div>
+
+      {hasPendingChange && (
+        <Alert>
+          <AlertDescription>
+            {penaltyChangeEffectiveDate} 부터 벌금제도가{' '}
+            {pendingPenaltyEnabled ? `켜짐(회당 ${pendingPenaltyPerMiss?.toLocaleString()}원)` : '꺼짐'}으로 전환될
+            예정입니다.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {isOwner && (
+        <Button type="button" variant="outline" onClick={onOpenSchedule}>
+          벌금제도 전환 예약
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/src/components/PenaltySettingsSection.tsx
+++ b/src/components/PenaltySettingsSection.tsx
@@ -27,23 +27,22 @@ export const PenaltySettingsSection = ({
     <div className="space-y-3">
       <div className="flex items-center gap-2">
         <Badge variant={penaltyEnabled ? 'default' : 'outline'}>
-          {penaltyEnabled ? `벌금제도 사용 중 (회당 ${penaltyPerMiss?.toLocaleString()}원)` : '벌금제도 미사용'}
+          {penaltyEnabled ? `벌금이 부과되는 운동방이에요. (회당 ${penaltyPerMiss?.toLocaleString()}원)` : '벌금 없이 운영되는 운동방이에요.'}
         </Badge>
       </div>
 
       {hasPendingChange && (
         <Alert>
           <AlertDescription>
-            {penaltyChangeEffectiveDate} 부터 벌금제도가{' '}
-            {pendingPenaltyEnabled ? `켜짐(회당 ${pendingPenaltyPerMiss?.toLocaleString()}원)` : '꺼짐'}으로 전환될
-            예정입니다.
+            {penaltyChangeEffectiveDate} 부터 벌금이{' '}
+            {pendingPenaltyEnabled ? `부과돼요.(회당 ${pendingPenaltyPerMiss?.toLocaleString()}원)` : '부과되지 않아요.'}
           </AlertDescription>
         </Alert>
       )}
 
       {isOwner && (
         <Button type="button" variant="outline" onClick={onOpenSchedule}>
-          벌금제도 전환 예약
+          운영 방식 바꾸기
         </Button>
       )}
     </div>

--- a/src/components/dashboard/StatsCards.tsx
+++ b/src/components/dashboard/StatsCards.tsx
@@ -51,7 +51,9 @@ export const StatsCards = ({ currentWorkoutRoom, member, isTodayRestDay }: Stats
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold text-red-600">
-            {currentWorkoutRoom.workoutRoomInfo.penaltyPerMiss}원
+            {currentWorkoutRoom.workoutRoomInfo.penaltyEnabled
+              ? `${currentWorkoutRoom.workoutRoomInfo.penaltyPerMiss?.toLocaleString()}원`
+              : '없음'}
           </div>
         </CardContent>
       </Card>

--- a/src/components/dialogs/AvailableRoomsDialog.tsx
+++ b/src/components/dialogs/AvailableRoomsDialog.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { formatPenaltyPerMiss } from '@/lib/workoutRoomRules';
 import { WorkoutRoom } from '@/types';
 import { List, Trophy, Users } from 'lucide-react';
 
@@ -56,7 +57,7 @@ export const AvailableRoomsDialog = ({
                       {workoutRoom.name}
                     </CardTitle>
                     <CardDescription>
-                      주 {workoutRoom.minWeeklyWorkouts}회 • 벌금 {workoutRoom.penaltyPerMiss.toLocaleString()}원
+                      주 {workoutRoom.minWeeklyWorkouts}회 • {formatPenaltyPerMiss(workoutRoom.penaltyPerMiss)}
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="flex-grow">

--- a/src/components/dialogs/PenaltyScheduleDialog.tsx
+++ b/src/components/dialogs/PenaltyScheduleDialog.tsx
@@ -1,0 +1,149 @@
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Switch } from '@/components/ui/switch';
+import { getEarliestPenaltyEffectiveMonday } from '@/lib/workoutRoomRules';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { Calendar as CalendarIcon } from 'lucide-react';
+
+interface PenaltyScheduleDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  penaltyEnabled: boolean;
+  pendingPenaltyEnabled?: boolean | null;
+  pendingPenaltyPerMiss?: number | null;
+  penaltyChangeEffectiveDate?: string | null;
+  targetEnabled: boolean;
+  onTargetEnabledChange: (enabled: boolean) => void;
+  penaltyPerMiss: string;
+  onPenaltyPerMissChange: (value: string) => void;
+  effectiveDate: Date | undefined;
+  onEffectiveDateChange: (date: Date | undefined) => void;
+  onSubmit: () => void;
+  onClose: () => void;
+  isSubmitting: boolean;
+  error: string;
+  today: Date;
+}
+
+export const PenaltyScheduleDialog = ({
+  open,
+  onOpenChange,
+  penaltyEnabled,
+  pendingPenaltyEnabled,
+  pendingPenaltyPerMiss,
+  penaltyChangeEffectiveDate,
+  targetEnabled,
+  onTargetEnabledChange,
+  penaltyPerMiss,
+  onPenaltyPerMissChange,
+  effectiveDate,
+  onEffectiveDateChange,
+  onSubmit,
+  onClose,
+  isSubmitting,
+  error,
+  today,
+}: PenaltyScheduleDialogProps) => {
+  const earliestMonday = getEarliestPenaltyEffectiveMonday(today);
+  const hasPendingChange = pendingPenaltyEnabled !== null && pendingPenaltyEnabled !== undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>벌금제도 전환 예약</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            현재 상태: {penaltyEnabled ? '벌금제도 사용 중' : '벌금제도 미사용'}
+          </p>
+
+          {hasPendingChange && (
+            <Alert>
+              <AlertDescription>
+                {penaltyChangeEffectiveDate} 부터 벌금제도가{' '}
+                {pendingPenaltyEnabled ? `켜짐(회당 ${pendingPenaltyPerMiss?.toLocaleString()}원)` : '꺼짐'}으로
+                전환될 예정입니다. 아래에서 다시 예약하면 이 예약은 새 예약으로 대체됩니다.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex items-center justify-between rounded-lg border p-3">
+            <div className="space-y-0.5">
+              <Label htmlFor="target-penalty-enabled">전환 후 상태</Label>
+              <p className="text-xs text-gray-500">{targetEnabled ? '벌금제도 켜짐' : '벌금제도 꺼짐'}</p>
+            </div>
+            <Switch id="target-penalty-enabled" checked={targetEnabled} onCheckedChange={onTargetEnabledChange} />
+          </div>
+
+          {targetEnabled && (
+            <div>
+              <Label htmlFor="schedule-penalty-amount">1회 누락당 벌금 (원)</Label>
+              <Input
+                id="schedule-penalty-amount"
+                type="number"
+                min="1000"
+                max="50000"
+                step="1000"
+                value={penaltyPerMiss}
+                onChange={(e) => onPenaltyPerMissChange(e.target.value)}
+                disabled={isSubmitting}
+                className="mt-1"
+              />
+            </div>
+          )}
+
+          <div>
+            <Label>전환 예정일</Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="w-full justify-start text-left font-normal mt-1"
+                  disabled={isSubmitting}
+                >
+                  <CalendarIcon className="mr-2 h-4 w-4" />
+                  {effectiveDate ? format(effectiveDate, 'yyyy-MM-dd', { locale: ko }) : '날짜 선택'}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0">
+                <Calendar
+                  mode="single"
+                  selected={effectiveDate}
+                  onSelect={onEffectiveDateChange}
+                  locale={ko}
+                  disabled={(date) => date.getDay() !== 1 || date < earliestMonday}
+                />
+              </PopoverContent>
+            </Popover>
+            <p className="text-xs text-gray-500 p-2">
+              월요일만 선택 가능하며, 오늘로부터 최소 7일 이후여야 합니다. (가장 빠른 날짜:{' '}
+              {format(earliestMonday, 'yyyy-MM-dd', { locale: ko })})
+            </p>
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex justify-end space-x-2">
+            <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+              취소
+            </Button>
+            <Button onClick={onSubmit} disabled={isSubmitting || !effectiveDate}>
+              {isSubmitting ? '예약 중...' : '예약'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/dialogs/PenaltyScheduleDialog.tsx
+++ b/src/components/dialogs/PenaltyScheduleDialog.tsx
@@ -57,27 +57,28 @@ export const PenaltyScheduleDialog = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>벌금제도 전환 예약</DialogTitle>
+          <DialogTitle>운영 방식 바꾸기</DialogTitle>
         </DialogHeader>
         <div className="space-y-4">
           <p className="text-sm text-muted-foreground">
-            현재 상태: {penaltyEnabled ? '벌금제도 사용 중' : '벌금제도 미사용'}
+            현재 이 운동방은 {penaltyEnabled ? '벌금제로 운영되고 있어요.' : '벌금없이 운영되고 있어요.'}
           </p>
 
           {hasPendingChange && (
             <Alert>
               <AlertDescription>
-                {penaltyChangeEffectiveDate} 부터 벌금제도가{' '}
-                {pendingPenaltyEnabled ? `켜짐(회당 ${pendingPenaltyPerMiss?.toLocaleString()}원)` : '꺼짐'}으로
-                전환될 예정입니다. 아래에서 다시 예약하면 이 예약은 새 예약으로 대체됩니다.
+                {penaltyChangeEffectiveDate} 부터 벌금이{' '}
+                {pendingPenaltyEnabled ? `부과돼요.(회당 ${pendingPenaltyPerMiss?.toLocaleString()}원)` : '부과되지 않아요'}
+                <br /><br />
+                아래에서 새로 예약 시 기존 예약은 무시됩니다.
               </AlertDescription>
             </Alert>
           )}
 
           <div className="flex items-center justify-between rounded-lg border p-3">
             <div className="space-y-0.5">
-              <Label htmlFor="target-penalty-enabled">전환 후 상태</Label>
-              <p className="text-xs text-gray-500">{targetEnabled ? '벌금제도 켜짐' : '벌금제도 꺼짐'}</p>
+              <Label htmlFor="target-penalty-enabled">벌금제 사용 여부</Label>
+              <p className="text-xs text-gray-500">{targetEnabled ? '사용' : '미사용 (벌금 없이 운동방 운영)'}</p>
             </div>
             <Switch id="target-penalty-enabled" checked={targetEnabled} onCheckedChange={onTargetEnabledChange} />
           </div>
@@ -123,7 +124,8 @@ export const PenaltyScheduleDialog = ({
               </PopoverContent>
             </Popover>
             <p className="text-xs text-gray-500 p-2">
-              월요일만 선택 가능하며, 오늘로부터 최소 7일 이후여야 합니다. (가장 빠른 날짜:{' '}
+              월요일만 선택 가능하며, 오늘로부터 최소 7일 이후여야 합니다. 
+              <br />(가장 빠른 날짜:{' '}
               {format(earliestMonday, 'yyyy-MM-dd', { locale: ko })})
             </p>
           </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,6 +8,7 @@ import {
   PageResponse,
   PenaltyPayment,
   PenaltyRecord,
+  SchedulePenaltyChangeRequest,
   WorkoutFeedItem,
   WorkoutRoom,
   WorkoutRoomDetail,
@@ -190,6 +191,20 @@ class ApiClient {
   async regenerateRoomEntryCode(roomId: number) {
     return this.request(`/workout/rooms/${roomId}/regenerate-entry-code`, {
       method: "POST",
+    });
+  }
+
+  async schedulePenaltyChange(roomId: number, body: SchedulePenaltyChangeRequest) {
+    return this.request(`/workout/rooms/${roomId}/penalty-schedule`, {
+      method: "PATCH",
+      data: body,
+    });
+  }
+
+  async scheduleAdminPenaltyChange(roomId: number, body: SchedulePenaltyChangeRequest) {
+    return this.request(`/admin/workout/rooms/${roomId}/penalty-schedule`, {
+      method: "PATCH",
+      data: body,
     });
   }
 

--- a/src/lib/workoutRoomRules.test.ts
+++ b/src/lib/workoutRoomRules.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPenaltyPerMiss,
+  getEarliestPenaltyEffectiveMonday,
+  validateWorkoutRoomRules,
+} from './workoutRoomRules';
+
+describe('validateWorkoutRoomRules', () => {
+  it('벌금제도가 켜져 있으면 벌금액이 범위를 벗어날 때 에러를 반환한다', () => {
+    const error = validateWorkoutRoomRules({
+      maxMembers: 5,
+      minWeeklyWorkouts: 3,
+      penaltyEnabled: true,
+      penaltyPerMiss: 500, // 최소 1000원 미만
+    });
+
+    expect(error).toBe('벌금은 1,000원 이상 50,000원 이하여야 합니다.');
+  });
+
+  it('벌금제도가 꺼져 있으면 벌금액이 범위를 벗어나도 통과한다', () => {
+    const error = validateWorkoutRoomRules({
+      maxMembers: 5,
+      minWeeklyWorkouts: 3,
+      penaltyEnabled: false,
+      penaltyPerMiss: 0,
+    });
+
+    expect(error).toBeNull();
+  });
+
+  it('penaltyEnabled를 생략하면 기존과 동일하게 벌금액을 검증한다(하위 호환)', () => {
+    const error = validateWorkoutRoomRules({
+      maxMembers: 5,
+      minWeeklyWorkouts: 3,
+      penaltyPerMiss: 500,
+    });
+
+    expect(error).toBe('벌금은 1,000원 이상 50,000원 이하여야 합니다.');
+  });
+});
+
+describe('getEarliestPenaltyEffectiveMonday', () => {
+  it('오늘이 토요일이면 최소 7일 이후의 월요일(오늘로부터 9일 뒤)을 반환한다', () => {
+    const saturday = new Date(2026, 6, 18); // 2026-07-18 (토)
+    const result = getEarliestPenaltyEffectiveMonday(saturday);
+
+    expect(result).toEqual(new Date(2026, 6, 27)); // 2026-07-27 (월)
+  });
+
+  it('오늘이 월요일이면 정확히 7일 뒤의 다음 월요일을 반환한다', () => {
+    const monday = new Date(2026, 6, 20); // 2026-07-20 (월)
+    const result = getEarliestPenaltyEffectiveMonday(monday);
+
+    expect(result).toEqual(new Date(2026, 6, 27)); // 2026-07-27 (월)
+  });
+
+  it('반환된 날짜는 항상 월요일이다', () => {
+    for (let offset = 0; offset < 7; offset += 1) {
+      const today = new Date(2026, 6, 18 + offset);
+      const result = getEarliestPenaltyEffectiveMonday(today);
+      expect(result.getDay()).toBe(1);
+    }
+  });
+});
+
+describe('formatPenaltyPerMiss', () => {
+  it('금액이 있으면 천 단위 콤마와 함께 표시한다', () => {
+    expect(formatPenaltyPerMiss(5000)).toBe('벌금 5,000원');
+  });
+
+  it('null이면 벌금 없음으로 표시한다', () => {
+    expect(formatPenaltyPerMiss(null)).toBe('벌금 없음');
+  });
+});

--- a/src/lib/workoutRoomRules.ts
+++ b/src/lib/workoutRoomRules.ts
@@ -6,6 +6,7 @@ function toInt(value: string | number): number {
 export type WorkoutRoomRulesValidationInput = {
   maxMembers: string | number;
   minWeeklyWorkouts: string | number;
+  penaltyEnabled?: boolean;
   penaltyPerMiss: string | number;
 };
 
@@ -13,7 +14,7 @@ export type WorkoutRoomRulesValidationInput = {
  * Validates room "rules" fields only:
  * - maxMembers
  * - minWeeklyWorkouts
- * - penaltyPerMiss
+ * - penaltyPerMiss (skipped when penaltyEnabled is explicitly false)
  */
 export function validateWorkoutRoomRules(input: WorkoutRoomRulesValidationInput): string | null {
   const minWorkouts = toInt(input.minWeeklyWorkouts);
@@ -21,9 +22,11 @@ export function validateWorkoutRoomRules(input: WorkoutRoomRulesValidationInput)
     return '주간 최소 운동 횟수는 1-7회 사이여야 합니다.';
   }
 
-  const penalty = toInt(input.penaltyPerMiss);
-  if (Number.isNaN(penalty) || penalty < 1000 || penalty > 50000) {
-    return '벌금은 1,000원 이상 50,000원 이하여야 합니다.';
+  if (input.penaltyEnabled !== false) {
+    const penalty = toInt(input.penaltyPerMiss);
+    if (Number.isNaN(penalty) || penalty < 1000 || penalty > 50000) {
+      return '벌금은 1,000원 이상 50,000원 이하여야 합니다.';
+    }
   }
 
   const maxMembersNum = toInt(input.maxMembers);
@@ -34,3 +37,28 @@ export function validateWorkoutRoomRules(input: WorkoutRoomRulesValidationInput)
   return null;
 }
 
+/**
+ * Formats a room's penalty amount for display, accounting for rooms that run
+ * without a fine system (penaltyPerMiss is null in that case).
+ */
+export function formatPenaltyPerMiss(penaltyPerMiss: number | null | undefined): string {
+  if (penaltyPerMiss == null) {
+    return '벌금 없음';
+  }
+  return `벌금 ${penaltyPerMiss.toLocaleString()}원`;
+}
+
+/**
+ * Earliest Monday a penalty enable/disable toggle may take effect: the first
+ * Monday that is at least 7 days from `today`. Mirrors the backend rule in
+ * WorkoutRoomService#validatePenaltyEffectiveDate.
+ */
+export function getEarliestPenaltyEffectiveMonday(today: Date): Date {
+  const minDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  minDate.setDate(minDate.getDate() + 7);
+
+  const daysUntilMonday = (1 - minDate.getDay() + 7) % 7;
+  minDate.setDate(minDate.getDate() + daysUntilMonday);
+
+  return minDate;
+}

--- a/src/pages/CreateRoomPage.test.tsx
+++ b/src/pages/CreateRoomPage.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreateRoomPage } from './CreateRoomPage';
+import { AuthProvider } from '@/contexts/AuthContext';
+import { api } from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    createWorkoutRoom: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <AuthProvider>
+        <CreateRoomPage />
+      </AuthProvider>
+    </MemoryRouter>
+  );
+
+const fillRequiredFieldsExceptPenalty = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByLabelText('방 이름 *'), '헬스 3개월 도전');
+  await user.click(screen.getByRole('button', { name: '코드 생성' }));
+};
+
+describe('CreateRoomPage - 벌금제도 토글', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('기본값은 벌금제도 켜짐이며 벌금액 입력란이 보인다', () => {
+    renderPage();
+    expect(screen.getByLabelText('1회 누락당 벌금 (원)')).toBeInTheDocument();
+  });
+
+  it('벌금제도 스위치를 끄면 벌금액 입력란이 사라진다', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByLabelText('벌금제도 사용'));
+
+    expect(screen.queryByLabelText('1회 누락당 벌금 (원)')).not.toBeInTheDocument();
+  });
+
+  it('벌금제도를 끄고 제출하면 penaltyPerMiss 없이 penaltyEnabled: false로 요청한다', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByLabelText('벌금제도 사용'));
+    await fillRequiredFieldsExceptPenalty(user);
+    await user.click(screen.getByRole('button', { name: '방 만들기' }));
+
+    await waitFor(() => {
+      expect(api.createWorkoutRoom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          penaltyEnabled: false,
+          penaltyPerMiss: undefined,
+        })
+      );
+    });
+  });
+
+  it('벌금제도가 켜진 채로 벌금액이 범위를 벗어나면 제출되지 않고 에러 메시지를 보여준다', async () => {
+    // 참고: input[type=number]에는 min="1000"/max="50000"이 걸려 있어, 사용자가 폼을
+    // 클릭 제출하면 브라우저(jsdom)의 네이티브 제약 검증이 먼저 막아 JS의 submit 핸들러
+    // 자체가 호출되지 않는다. 여기서는 JS 레벨 검증(validateWorkoutRoomRules) 로직 자체를
+    // 검증하기 위해 네이티브 검증을 우회하고 form의 submit 이벤트를 직접 발생시킨다.
+    const user = userEvent.setup();
+    const { container } = renderPage();
+
+    await fillRequiredFieldsExceptPenalty(user);
+    await user.clear(screen.getByLabelText('1회 누락당 벌금 (원)'));
+    await user.type(screen.getByLabelText('1회 누락당 벌금 (원)'), '500');
+
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    expect(await screen.findByText('벌금은 1,000원 이상 50,000원 이하여야 합니다.')).toBeInTheDocument();
+    expect(api.createWorkoutRoom).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/CreateRoomPage.tsx
+++ b/src/pages/CreateRoomPage.tsx
@@ -150,9 +150,9 @@ export const CreateRoomPage = () => {
               <div className="space-y-2 rounded-lg border p-4">
                 <div className="flex items-center justify-between">
                   <div className="space-y-0.5">
-                    <Label htmlFor="penalty-enabled">벌금제도 사용</Label>
+                    <Label htmlFor="penalty-enabled">벌금제 사용 여부</Label>
                     <p className="text-xs text-gray-500">
-                      끄면 벌금 없이 운동 인증 용도로만 방을 운영합니다.
+                      미사용 시 벌금 없이 운동방을 운영합니다.
                     </p>
                   </div>
                   <Switch

--- a/src/pages/CreateRoomPage.tsx
+++ b/src/pages/CreateRoomPage.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { api } from '@/lib/api';
 import { validateWorkoutRoomRules } from '@/lib/workoutRoomRules';
 import { Loader2 } from 'lucide-react';
@@ -19,6 +20,7 @@ export const CreateRoomPage = () => {
   const [roomName, setRoomName] = useState('');
   const [entryCode, setEntryCode] = useState('');
   const [minWeeklyWorkouts, setMinWeeklyWorkouts] = useState('3');
+  const [penaltyEnabled, setPenaltyEnabled] = useState(true);
   const [penaltyPerMiss, setPenaltyPerMiss] = useState('5000');
   const [maxMembers, setMaxMembers] = useState('10');
   const [loading, setLoading] = useState(false);
@@ -51,6 +53,7 @@ export const CreateRoomPage = () => {
     const rulesError = validateWorkoutRoomRules({
       maxMembers,
       minWeeklyWorkouts,
+      penaltyEnabled,
       penaltyPerMiss,
     });
     if (rulesError) {
@@ -89,7 +92,8 @@ export const CreateRoomPage = () => {
       const workoutRoomData = {
         name: roomName.trim(),
         minWeeklyWorkouts: parseInt(minWeeklyWorkouts),
-        penaltyPerMiss: parseInt(penaltyPerMiss),
+        penaltyEnabled,
+        penaltyPerMiss: penaltyEnabled ? parseInt(penaltyPerMiss) : undefined,
         maxMembers: parseInt(maxMembers),
         entryCode: entryCode.trim(),
       };
@@ -141,20 +145,39 @@ export const CreateRoomPage = () => {
                   />
                   <p className="text-xs text-gray-500">일주일에 최소 몇 번 운동할지 설정하세요</p>
                 </div>
+              </div>
 
-                <div className="space-y-2">
-                  <Label htmlFor="penalty">1회 누락당 벌금 (원)</Label>
-                  <Input
-                    id="penalty"
-                    type="number"
-                    min="1000"
-                    max="50000"
-                    step="1000"
-                    value={penaltyPerMiss}
-                    onChange={(e) => setPenaltyPerMiss(e.target.value)}
+              <div className="space-y-2 rounded-lg border p-4">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="penalty-enabled">벌금제도 사용</Label>
+                    <p className="text-xs text-gray-500">
+                      끄면 벌금 없이 운동 인증 용도로만 방을 운영합니다.
+                    </p>
+                  </div>
+                  <Switch
+                    id="penalty-enabled"
+                    checked={penaltyEnabled}
+                    onCheckedChange={setPenaltyEnabled}
                   />
-                  <p className="text-xs text-gray-500">운동을 빠뜨릴 때마다 부과될 벌금</p>
                 </div>
+
+                {penaltyEnabled && (
+                  <div className="space-y-2 pt-2">
+                    <Label htmlFor="penalty">1회 누락당 벌금 (원)</Label>
+                    <Input
+                      id="penalty"
+                      type="number"
+                      min="1000"
+                      max="50000"
+                      step="1000"
+                      value={penaltyPerMiss}
+                      onChange={(e) => setPenaltyPerMiss(e.target.value)}
+                      className="max-w-xs"
+                    />
+                    <p className="text-xs text-gray-500">운동을 빠뜨릴 때마다 부과될 벌금</p>
+                  </div>
+                )}
               </div>
 
               <div className="space-y-2">

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { MyActivityCard } from '@/components/dashboard/MyActivityCard';
 import { StatsCards } from '@/components/dashboard/StatsCards';
 import { AvailableRoomsDialog } from '@/components/dialogs/AvailableRoomsDialog';
+import { PenaltyScheduleDialog } from '@/components/dialogs/PenaltyScheduleDialog';
 import { RoomCodeDialog } from '@/components/dialogs/RoomCodeDialog';
 import { RestDayDialog } from '@/components/dialogs/RestDayDialog';
 import { Layout } from '@/components/layout/Layout';
@@ -14,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
+import { format } from 'date-fns';
 import { useDashboardData } from '@/hooks/useDashboardData';
 import { useRestDay } from '@/hooks/useRestDay';
 import { useRoomJoin } from '@/hooks/useRoomJoin';
@@ -113,6 +115,14 @@ export const DashboardPage = () => {
   const [joinedRoomIds, setJoinedRoomIds] = useState<number[]>([]);
   const [isRegeneratingEntryCode, setIsRegeneratingEntryCode] = useState(false);
 
+  // 벌금제도 전환 예약 다이얼로그 관련 상태
+  const [showPenaltyScheduleDialog, setShowPenaltyScheduleDialog] = useState(false);
+  const [penaltyScheduleTargetEnabled, setPenaltyScheduleTargetEnabled] = useState(true);
+  const [penaltyScheduleAmount, setPenaltyScheduleAmount] = useState('5000');
+  const [penaltyScheduleDate, setPenaltyScheduleDate] = useState<Date | undefined>(undefined);
+  const [isSchedulingPenaltyChange, setIsSchedulingPenaltyChange] = useState(false);
+  const [penaltyScheduleError, setPenaltyScheduleError] = useState('');
+
   // 오늘이 휴식일인지 확인하는 함수
   const isTodayRestDay = () => {
     if (!currentWorkoutRoom) return false;
@@ -192,6 +202,54 @@ export const DashboardPage = () => {
     setShowAvailableRoomsDialog(false);
   };
 
+  const handleOpenPenaltySchedule = () => {
+    const room = currentWorkoutRoom?.workoutRoomInfo;
+    if (!room) return;
+    setPenaltyScheduleTargetEnabled(!room.penaltyEnabled);
+    setPenaltyScheduleAmount(String(room.penaltyPerMiss ?? 5000));
+    setPenaltyScheduleDate(undefined);
+    setPenaltyScheduleError('');
+    setShowPenaltyScheduleDialog(true);
+  };
+
+  const handlePenaltyScheduleDialogClose = () => {
+    setShowPenaltyScheduleDialog(false);
+    setPenaltyScheduleError('');
+  };
+
+  const handleSchedulePenaltyChange = async () => {
+    const roomId = currentWorkoutRoom?.workoutRoomInfo?.id;
+    if (!roomId || !penaltyScheduleDate) return;
+
+    if (penaltyScheduleTargetEnabled) {
+      const amount = parseInt(penaltyScheduleAmount, 10);
+      if (Number.isNaN(amount) || amount < 1000 || amount > 50000) {
+        setPenaltyScheduleError('벌금은 1,000원 이상 50,000원 이하여야 합니다.');
+        return;
+      }
+    }
+
+    setIsSchedulingPenaltyChange(true);
+    setPenaltyScheduleError('');
+    try {
+      const effectiveDate = format(penaltyScheduleDate, 'yyyy-MM-dd');
+      await api.schedulePenaltyChange(roomId, {
+        penaltyEnabled: penaltyScheduleTargetEnabled,
+        penaltyPerMiss: penaltyScheduleTargetEnabled ? parseInt(penaltyScheduleAmount, 10) : undefined,
+        effectiveDate,
+      });
+      const detail = await api.getWorkoutRoomDetail(roomId) as WorkoutRoomDetail;
+      setCurrentWorkoutRoom(detail);
+      setShowPenaltyScheduleDialog(false);
+      toast.success('벌금제도 전환이 예약되었습니다.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '예약에 실패했습니다. 잠시 후 다시 시도해주세요.';
+      setPenaltyScheduleError(msg);
+    } finally {
+      setIsSchedulingPenaltyChange(false);
+    }
+  };
+
   if (isLoading || !availableWorkoutRooms) {
     return (
       <Layout>
@@ -264,6 +322,7 @@ export const DashboardPage = () => {
                 currentMember={member}
                 onRegenerateEntryCode={handleRegenerateEntryCode}
                 isRegeneratingEntryCode={isRegeneratingEntryCode}
+                onOpenPenaltySchedule={handleOpenPenaltySchedule}
               />
             </TabsContent>
 
@@ -321,6 +380,29 @@ export const DashboardPage = () => {
           error={restDay.error}
           today={restDay.today}
         />
+
+        {/* 벌금제도 전환 예약 다이얼로그 */}
+        {currentWorkoutRoom?.workoutRoomInfo && (
+          <PenaltyScheduleDialog
+            open={showPenaltyScheduleDialog}
+            onOpenChange={setShowPenaltyScheduleDialog}
+            penaltyEnabled={currentWorkoutRoom.workoutRoomInfo.penaltyEnabled}
+            pendingPenaltyEnabled={currentWorkoutRoom.workoutRoomInfo.pendingPenaltyEnabled}
+            pendingPenaltyPerMiss={currentWorkoutRoom.workoutRoomInfo.pendingPenaltyPerMiss}
+            penaltyChangeEffectiveDate={currentWorkoutRoom.workoutRoomInfo.penaltyChangeEffectiveDate}
+            targetEnabled={penaltyScheduleTargetEnabled}
+            onTargetEnabledChange={setPenaltyScheduleTargetEnabled}
+            penaltyPerMiss={penaltyScheduleAmount}
+            onPenaltyPerMissChange={setPenaltyScheduleAmount}
+            effectiveDate={penaltyScheduleDate}
+            onEffectiveDateChange={setPenaltyScheduleDate}
+            onSubmit={handleSchedulePenaltyChange}
+            onClose={handlePenaltyScheduleDialogClose}
+            isSubmitting={isSchedulingPenaltyChange}
+            error={penaltyScheduleError}
+            today={today}
+          />
+        )}
 
         {/* 휴식일 등록 성공 다이얼로그 */}
         <Dialog open={restDay.showRestSuccessDialog} onOpenChange={(open) => !open && restDay.handleRestSuccessDialogClose()}>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -241,7 +241,7 @@ export const DashboardPage = () => {
       const detail = await api.getWorkoutRoomDetail(roomId) as WorkoutRoomDetail;
       setCurrentWorkoutRoom(detail);
       setShowPenaltyScheduleDialog(false);
-      toast.success('벌금제도 전환이 예약되었습니다.');
+      toast.success('운동방 운영 방식 바꾸기 예약이 완료되었습니다.');
     } catch (err) {
       const msg = err instanceof Error ? err.message : '예약에 실패했습니다. 잠시 후 다시 시도해주세요.';
       setPenaltyScheduleError(msg);

--- a/src/pages/JoinedRoomsPage.tsx
+++ b/src/pages/JoinedRoomsPage.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { api } from '@/lib/api';
+import { formatPenaltyPerMiss } from '@/lib/workoutRoomRules';
 import { WorkoutRoom } from '@/types';
 import { Eye, List, Users } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -71,7 +72,7 @@ const JoinedRoomsPage = () => {
                 <CardHeader>
                   <CardTitle>{room.name}</CardTitle>
                   <CardDescription>
-                    주 {room.minWeeklyWorkouts}회 • 벌금 {room.penaltyPerMiss.toLocaleString()}원
+                    주 {room.minWeeklyWorkouts}회 • {formatPenaltyPerMiss(room.penaltyPerMiss)}
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="flex-grow space-y-2">

--- a/src/pages/admin/AdminRoomDetailPage.tsx
+++ b/src/pages/admin/AdminRoomDetailPage.tsx
@@ -15,6 +15,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { AdminStateBlock } from '@/components/admin/AdminStateBlock';
 import { AdminRoomMembersTab } from '@/components/admin/AdminRoomMembersTab';
 import { AdminRoomChatTab } from '@/components/admin/AdminRoomChatTab';
+import { PenaltyScheduleDialog } from '@/components/dialogs/PenaltyScheduleDialog';
+
+const today = new Date();
+today.setHours(0, 0, 0, 0);
 
 const AdminRoomDetailPage = () => {
   const { roomId } = useParams();
@@ -38,6 +42,12 @@ const AdminRoomDetailPage = () => {
   const [penaltyPerMiss, setPenaltyPerMiss] = useState('5000');
   const [localError, setLocalError] = useState('');
   const [activeTab, setActiveTab] = useState('settings');
+
+  const [showPenaltyScheduleDialog, setShowPenaltyScheduleDialog] = useState(false);
+  const [penaltyScheduleTargetEnabled, setPenaltyScheduleTargetEnabled] = useState(true);
+  const [penaltyScheduleAmount, setPenaltyScheduleAmount] = useState('5000');
+  const [penaltyScheduleDate, setPenaltyScheduleDate] = useState<Date | undefined>(undefined);
+  const [penaltyScheduleError, setPenaltyScheduleError] = useState('');
 
   // When navigating between room IDs without unmount, reset initialization.
   useEffect(() => {
@@ -88,6 +98,47 @@ const AdminRoomDetailPage = () => {
       const msg = err instanceof Error ? err.message : '저장에 실패했습니다. 잠시 후 다시 시도해주세요.';
       setLocalError(msg);
       toast.error(msg);
+    },
+  });
+
+  const handleOpenPenaltySchedule = () => {
+    if (!room) return;
+    setPenaltyScheduleTargetEnabled(!room.penaltyEnabled);
+    setPenaltyScheduleAmount(String(room.penaltyPerMiss ?? 5000));
+    setPenaltyScheduleDate(undefined);
+    setPenaltyScheduleError('');
+    setShowPenaltyScheduleDialog(true);
+  };
+
+  const schedulePenaltyMutation = useMutation({
+    mutationFn: async () => {
+      if (!Number.isFinite(numericRoomId)) throw new Error('유효하지 않은 roomId 입니다.');
+      if (!penaltyScheduleDate) throw new Error('전환 예정일을 선택해주세요.');
+
+      if (penaltyScheduleTargetEnabled) {
+        const amount = Number.parseInt(penaltyScheduleAmount, 10);
+        if (Number.isNaN(amount) || amount < 1000 || amount > 50000) {
+          throw new Error('벌금은 1,000원 이상 50,000원 이하여야 합니다.');
+        }
+      }
+
+      const effectiveDate = `${penaltyScheduleDate.getFullYear()}-${String(penaltyScheduleDate.getMonth() + 1).padStart(2, '0')}-${String(penaltyScheduleDate.getDate()).padStart(2, '0')}`;
+
+      return api.scheduleAdminPenaltyChange(numericRoomId, {
+        penaltyEnabled: penaltyScheduleTargetEnabled,
+        penaltyPerMiss: penaltyScheduleTargetEnabled ? Number.parseInt(penaltyScheduleAmount, 10) : undefined,
+        effectiveDate,
+      });
+    },
+    onSuccess: () => {
+      toast.success('벌금제도 전환이 예약되었습니다.');
+      setShowPenaltyScheduleDialog(false);
+      setPenaltyScheduleError('');
+      queryClient.invalidateQueries({ queryKey: ['adminWorkoutRoomDetail', numericRoomId] });
+    },
+    onError: (err) => {
+      const msg = err instanceof Error ? err.message : '예약에 실패했습니다. 잠시 후 다시 시도해주세요.';
+      setPenaltyScheduleError(msg);
     },
   });
 
@@ -228,6 +279,37 @@ const AdminRoomDetailPage = () => {
                   </div>
                 </CardContent>
               </Card>
+
+              <Card className="mt-4">
+                <CardHeader>
+                  <CardTitle>벌금제도 전환 예약</CardTitle>
+                  <CardDescription>
+                    벌금제도 사용 여부는 즉시 반영되지 않고, 오늘로부터 최소 7일 이후의 월요일부터 적용되도록
+                    예약합니다.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4 p-4 sm:p-6">
+                  <p className="text-sm text-muted-foreground">
+                    현재 상태: {room.penaltyEnabled ? `벌금제도 사용 중 (회당 ${room.penaltyPerMiss?.toLocaleString()}원)` : '벌금제도 미사용'}
+                  </p>
+
+                  {room.pendingPenaltyEnabled !== null && room.pendingPenaltyEnabled !== undefined ? (
+                    <Alert>
+                      <AlertDescription>
+                        {room.penaltyChangeEffectiveDate} 부터 벌금제도가{' '}
+                        {room.pendingPenaltyEnabled
+                          ? `켜짐(회당 ${room.pendingPenaltyPerMiss?.toLocaleString()}원)`
+                          : '꺼짐'}
+                        으로 전환될 예정입니다.
+                      </AlertDescription>
+                    </Alert>
+                  ) : null}
+
+                  <Button type="button" variant="outline" onClick={handleOpenPenaltySchedule}>
+                    벌금제도 전환 예약
+                  </Button>
+                </CardContent>
+              </Card>
             </TabsContent>
 
             <TabsContent value="members" className="mt-3 md:mt-4">
@@ -248,6 +330,31 @@ const AdminRoomDetailPage = () => {
             </TabsContent>
           </Tabs>
         )}
+
+        {room ? (
+          <PenaltyScheduleDialog
+            open={showPenaltyScheduleDialog}
+            onOpenChange={setShowPenaltyScheduleDialog}
+            penaltyEnabled={room.penaltyEnabled}
+            pendingPenaltyEnabled={room.pendingPenaltyEnabled}
+            pendingPenaltyPerMiss={room.pendingPenaltyPerMiss}
+            penaltyChangeEffectiveDate={room.penaltyChangeEffectiveDate}
+            targetEnabled={penaltyScheduleTargetEnabled}
+            onTargetEnabledChange={setPenaltyScheduleTargetEnabled}
+            penaltyPerMiss={penaltyScheduleAmount}
+            onPenaltyPerMissChange={setPenaltyScheduleAmount}
+            effectiveDate={penaltyScheduleDate}
+            onEffectiveDateChange={setPenaltyScheduleDate}
+            onSubmit={() => schedulePenaltyMutation.mutate()}
+            onClose={() => {
+              setShowPenaltyScheduleDialog(false);
+              setPenaltyScheduleError('');
+            }}
+            isSubmitting={schedulePenaltyMutation.isPending}
+            error={penaltyScheduleError}
+            today={today}
+          />
+        ) : null}
       </div>
     </Layout>
   );

--- a/src/pages/admin/AdminRoomDetailPage.tsx
+++ b/src/pages/admin/AdminRoomDetailPage.tsx
@@ -131,7 +131,7 @@ const AdminRoomDetailPage = () => {
       });
     },
     onSuccess: () => {
-      toast.success('벌금제도 전환이 예약되었습니다.');
+      toast.success('운영방식 바꾸기 예약이 완료되었습니다.');
       setShowPenaltyScheduleDialog(false);
       setPenaltyScheduleError('');
       queryClient.invalidateQueries({ queryKey: ['adminWorkoutRoomDetail', numericRoomId] });
@@ -282,7 +282,7 @@ const AdminRoomDetailPage = () => {
 
               <Card className="mt-4">
                 <CardHeader>
-                  <CardTitle>벌금제도 전환 예약</CardTitle>
+                  <CardTitle>운영 방식 바꾸기</CardTitle>
                   <CardDescription>
                     벌금제도 사용 여부는 즉시 반영되지 않고, 오늘로부터 최소 7일 이후의 월요일부터 적용되도록
                     예약합니다.
@@ -296,17 +296,17 @@ const AdminRoomDetailPage = () => {
                   {room.pendingPenaltyEnabled !== null && room.pendingPenaltyEnabled !== undefined ? (
                     <Alert>
                       <AlertDescription>
-                        {room.penaltyChangeEffectiveDate} 부터 벌금제도가{' '}
+                        {room.penaltyChangeEffectiveDate} 부터 벌금이{' '}
                         {room.pendingPenaltyEnabled
-                          ? `켜짐(회당 ${room.pendingPenaltyPerMiss?.toLocaleString()}원)`
-                          : '꺼짐'}
+                          ? `부과돼요.(회당 ${room.pendingPenaltyPerMiss?.toLocaleString()}원)`
+                          : '부과되지 않아요.'}
                         으로 전환될 예정입니다.
                       </AlertDescription>
                     </Alert>
                   ) : null}
 
                   <Button type="button" variant="outline" onClick={handleOpenPenaltySchedule}>
-                    벌금제도 전환 예약
+                    운영방식 바꾸기
                   </Button>
                 </CardContent>
               </Card>

--- a/src/pages/admin/AdminRoomsPage.tsx
+++ b/src/pages/admin/AdminRoomsPage.tsx
@@ -16,6 +16,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { formatPenaltyPerMiss } from '@/lib/workoutRoomRules';
 import { WorkoutRoom } from '@/types';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { RefreshCcw, Search, Trash2 } from 'lucide-react';
@@ -228,9 +229,7 @@ const AdminRoomsPage = () => {
                   {content.map((r: WorkoutRoom) => {
                     const activeLabel = r.isActive ? '활성' : '비활성';
                     const membersText = `${r.currentMembers ?? 0} / ${r.maxMembers ?? 0}`;
-                    const rulesText = `주 ${r.minWeeklyWorkouts ?? 0}회 · 미달 ${(
-                      r.penaltyPerMiss ?? 0
-                    ).toLocaleString()}원`;
+                    const rulesText = `주 ${r.minWeeklyWorkouts ?? 0}회 · 미달 ${formatPenaltyPerMiss(r.penaltyPerMiss)}`;
                     const isDeletingThisRow = deleteMutation.isPending && pendingDelete.target?.id === r.id;
 
                     return (
@@ -305,9 +304,7 @@ const AdminRoomsPage = () => {
                         {content.map((r: WorkoutRoom) => {
                           const activeLabel = r.isActive ? '활성' : '비활성';
                           const membersText = `${r.currentMembers ?? 0} / ${r.maxMembers ?? 0}`;
-                          const rulesText = `주 ${r.minWeeklyWorkouts ?? 0}회 · 미달 ${(
-                            r.penaltyPerMiss ?? 0
-                          ).toLocaleString()}원`;
+                          const rulesText = `주 ${r.minWeeklyWorkouts ?? 0}회 · 미달 ${formatPenaltyPerMiss(r.penaltyPerMiss)}`;
                           const isDeletingThisRow = deleteMutation.isPending && pendingDelete.target?.id === r.id;
                           return (
                             <TableRow key={r.id}>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,24 @@
+import '@testing-library/jest-dom';
+
+// jsdom doesn't implement ResizeObserver; Radix UI primitives (e.g. Switch) rely on it.
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+// jsdom doesn't implement matchMedia; several UI components (e.g. use-mobile hook) rely on it.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }) as unknown as MediaQueryList;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,12 +22,22 @@ export interface WorkoutRoom {
   id: number;
   name: string;
   minWeeklyWorkouts: number;
-  penaltyPerMiss: number;
+  penaltyEnabled: boolean;
+  penaltyPerMiss: number | null;
+  pendingPenaltyEnabled?: boolean | null;
+  pendingPenaltyPerMiss?: number | null;
+  penaltyChangeEffectiveDate?: string | null;
   maxMembers: number;
   currentMembers: number;
   ownerNickname: string;
   isActive: boolean;
   entryCode?: string;
+}
+
+export interface SchedulePenaltyChangeRequest {
+  penaltyEnabled: boolean;
+  penaltyPerMiss?: number;
+  effectiveDate: string;
 }
 
 export interface WorkoutRoomDetail {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.ts',
+  },
+});


### PR DESCRIPTION
Closes #132

## Description

운동방 생성 시 벌금제도 사용 여부를 선택할 수 있도록 하고, 방장/관리자가 이후에도 벌금제도를 켜고 끌 수
있는 예약 전환 UI를 추가했습니다. 백엔드 BE-HCM#119(PR BellWin98/BE-HCM#120)와 짝을 이루는 프론트엔드
작업입니다.

- `CreateRoomPage`: 벌금제도 on/off 스위치, 꺼져 있으면 금액 입력란 숨김 및 검증 생략
- 신규 `PenaltyScheduleDialog`: 월요일만/최소 7일 이후만 선택 가능한 날짜 선택기 + 예약 상태 배너
- 신규 `PenaltySettingsSection` + `MyWorkoutRoom`/`DashboardPage` 연동: 방장이 대시보드에서 직접 벌금제도
  전환을 예약(기존에는 방장용 방 설정 화면이 없었음)
- `AdminRoomDetailPage`: 관리자용 벌금제도 전환 예약 UI(기존 즉시 반영 설정 폼과 별개로 추가)
- `api.ts`: `schedulePenaltyChange` / `scheduleAdminPenaltyChange` 추가
- `penaltyPerMiss`가 null일 수 있는 방에 대응해 여러 화면의 표시 로직 수정
- Vitest + Testing Library 테스트 환경 신규 구축

## Test plan

- [x] `npm run test` (Vitest, 신규 12개 테스트 통과)
- [x] `npm run lint`
- [x] `npm run build`
- [x] RED-GREEN-REFACTOR로 벌금 토글/날짜 제약 로직 검증