### PR TITLE
feat: 카카오톡 초대 딥링크 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ npm run preview   # 빌드 결과 미리보기
 - `VITE_WS_URL` — STOMP/WebSocket 베이스 URL (기본값 `http://localhost:8080`, `src/components/ChatRoom.tsx`)
 - `VITE_FIREBASE_*` (API_KEY, AUTH_DOMAIN, PROJECT_ID, SENDER_ID, APP_ID, VAPID_KEY) — FCM 푸시 알림용
   Firebase 설정 (`src/lib/firebase.ts`)
+- `VITE_KAKAO_JS_KEY` — 카카오톡 초대 공유(`src/lib/kakao.ts`)에 사용하는 카카오 디벨로퍼스 앱의
+  JavaScript 키. 미설정 시 초대 공유 버튼은 "초대 링크 복사" 버튼으로 자동 대체된다. 실제 발송을 테스트하려면
+  [Kakao Developers](https://developers.kakao.com)에서 앱을 등록하고 사용 중인 도메인을 JavaScript SDK
+  허용 도메인에 추가해야 한다.
 
 ## 아키텍처
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import AdminMembersPage from './pages/admin/AdminMembersPage';
 import AdminRoomsPage from './pages/admin/AdminRoomsPage';
 import AdminRoomDetailPage from './pages/admin/AdminRoomDetailPage';
 import OAuthCallbackPage from './pages/OAuthCallbackPage';
+import JoinRoomPage from './pages/JoinRoomPage';
 
 const queryClient = new QueryClient();
 
@@ -45,6 +46,7 @@ const AppRoutes = () => (
     <Route path="/login" element={<LoginPage />} />
     <Route path="/register" element={<RegisterPage />} />
     <Route path="/oauth/callback" element={<OAuthCallbackPage />} />
+    <Route path="/join" element={<JoinRoomPage />} />
     <Route path="/dashboard" element={
       <ProtectedRoute>
         <DashboardPage />

--- a/src/components/MyWorkoutRoom.tsx
+++ b/src/components/MyWorkoutRoom.tsx
@@ -225,6 +225,7 @@ export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRege
             </CardHeader>
             <CardContent>
               <RoomCodeSection
+                roomName={currentWorkoutRoom.workoutRoomInfo?.name ?? ''}
                 entryCode={entryCode}
                 isOwner={isOwner}
                 onRegenerate={onRegenerateEntryCode}

--- a/src/components/RoomCodeSection.tsx
+++ b/src/components/RoomCodeSection.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Copy, RefreshCw } from 'lucide-react';
+import { Copy, Link as LinkIcon, RefreshCw } from 'lucide-react';
 import { toast } from '@/components/ui/sonner';
+import { useKakaoShare } from '@/hooks/useKakaoShare';
+import { buildRoomInviteUrl } from '@/lib/kakao';
 
 interface RoomCodeSectionProps {
+  roomName: string;
   entryCode: string;
   isOwner: boolean;
   onRegenerate?: () => void;
@@ -12,11 +14,14 @@ interface RoomCodeSectionProps {
 }
 
 export const RoomCodeSection = ({
+  roomName,
   entryCode,
   isOwner,
   onRegenerate,
   isRegenerating = false,
 }: RoomCodeSectionProps) => {
+  const { share: shareToKakao, isSharing, isAvailable: isKakaoAvailable } = useKakaoShare();
+
   const handleCopy = async () => {
     if (!entryCode) return;
     try {
@@ -27,9 +32,24 @@ export const RoomCodeSection = ({
     }
   };
 
+  const handleCopyInviteLink = async () => {
+    if (!entryCode) return;
+    try {
+      await navigator.clipboard.writeText(buildRoomInviteUrl(entryCode));
+      toast('초대 링크가 복사되었습니다.');
+    } catch {
+      toast.error('복사에 실패했습니다.');
+    }
+  };
+
+  const handleKakaoShare = () => {
+    if (!entryCode) return;
+    shareToKakao({ roomName, entryCode });
+  };
+
   return (
     <div className="space-y-2">
-      <div className="flex gap-2 items-center">
+      <div className="flex gap-2 items-center flex-wrap">
         <Input
           value={entryCode || '로딩 중...'}
           readOnly
@@ -45,6 +65,28 @@ export const RoomCodeSection = ({
         >
           <Copy className="h-4 w-4" />
         </Button>
+        {isKakaoAvailable ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="bg-[#FEE500] hover:bg-[#FDD835] text-[#191919] border-[#FEE500]"
+            onClick={handleKakaoShare}
+            disabled={!entryCode || isSharing}
+          >
+            카카오톡으로 초대
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCopyInviteLink}
+            disabled={!entryCode}
+            title="초대 링크 복사"
+          >
+            <LinkIcon className="h-4 w-4 mr-1" />
+            초대 링크 복사
+          </Button>
+        )}
         {isOwner && onRegenerate && (
           <Button
             type="button"
@@ -59,7 +101,7 @@ export const RoomCodeSection = ({
         )}
       </div>
       <p className="text-xs text-muted-foreground">
-        다른 사람들과 공유할 입장 코드입니다. 복사하여 공유하세요.
+        다른 사람들과 공유할 입장 코드입니다. 복사하거나 초대 링크로 공유하세요.
       </p>
     </div>
   );

--- a/src/hooks/useKakaoShare.ts
+++ b/src/hooks/useKakaoShare.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { isKakaoShareAvailable, shareRoomInvite } from '@/lib/kakao';
+import { toast } from '@/components/ui/sonner';
+
+interface ShareRoomInviteParams {
+  roomName: string;
+  entryCode: string;
+}
+
+export const useKakaoShare = () => {
+  const [isSharing, setIsSharing] = useState(false);
+
+  const share = async (params: ShareRoomInviteParams): Promise<void> => {
+    setIsSharing(true);
+    try {
+      await shareRoomInvite(params);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : '카카오톡 공유에 실패했습니다.');
+    } finally {
+      setIsSharing(false);
+    }
+  };
+
+  return { share, isSharing, isAvailable: isKakaoShareAvailable() };
+};

--- a/src/lib/kakao.ts
+++ b/src/lib/kakao.ts
@@ -1,0 +1,88 @@
+declare global {
+  interface Window {
+    Kakao?: {
+      isInitialized: () => boolean;
+      init: (key: string) => void;
+      Share: {
+        sendDefault: (options: Record<string, unknown>) => void;
+      };
+    };
+  }
+}
+
+const KAKAO_SDK_SRC = 'https://developers.kakao.com/sdk/js/kakao.js';
+
+/**
+ * 여러 컴포넌트에서 호출되더라도 SDK 스크립트 로드는 한 번만 수행된다.
+ */
+let loadPromise: Promise<void> | null = null;
+
+const loadKakaoSdk = (): Promise<void> => {
+  if (window.Kakao) return Promise.resolve();
+  if (loadPromise) return loadPromise;
+
+  loadPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = KAKAO_SDK_SRC;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      loadPromise = null;
+      reject(new Error('카카오 SDK 로드에 실패했습니다.'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return loadPromise;
+};
+
+export const isKakaoShareAvailable = (): boolean => Boolean(import.meta.env.VITE_KAKAO_JS_KEY);
+
+const ensureKakaoInitialized = async (): Promise<void> => {
+  const jsKey = import.meta.env.VITE_KAKAO_JS_KEY;
+  if (!jsKey) {
+    throw new Error('카카오톡 공유가 아직 설정되지 않았어요.');
+  }
+
+  await loadKakaoSdk();
+
+  if (!window.Kakao?.isInitialized()) {
+    window.Kakao?.init(jsKey);
+  }
+};
+
+export const buildRoomInviteUrl = (entryCode: string): string =>
+  `${window.location.origin}/join?code=${encodeURIComponent(entryCode)}`;
+
+interface ShareRoomInviteParams {
+  roomName: string;
+  entryCode: string;
+}
+
+export const shareRoomInvite = async ({ roomName, entryCode }: ShareRoomInviteParams): Promise<void> => {
+  await ensureKakaoInitialized();
+
+  const inviteUrl = buildRoomInviteUrl(entryCode);
+
+  window.Kakao?.Share.sendDefault({
+    objectType: 'feed',
+    content: {
+      title: `${roomName} 운동방 초대`,
+      description: `입장 코드 ${entryCode}로 바로 참여할 수 있어요. 같이 운동해요!`,
+      imageUrl: 'https://hcm-bucket-dev.s3.ap-northeast-2.amazonaws.com/HCM_LOGO.png',
+      link: {
+        mobileWebUrl: inviteUrl,
+        webUrl: inviteUrl,
+      },
+    },
+    buttons: [
+      {
+        title: '바로 참여하기',
+        link: {
+          mobileWebUrl: inviteUrl,
+          webUrl: inviteUrl,
+        },
+      },
+    ],
+  });
+};

--- a/src/lib/pendingJoinCode.ts
+++ b/src/lib/pendingJoinCode.ts
@@ -1,0 +1,17 @@
+const PENDING_JOIN_CODE_KEY = 'pendingJoinCode';
+
+/**
+ * 카카오 초대 링크(/join?code=...)로 들어온 미로그인 사용자가 로그인을 마친 뒤
+ * 원래 참여하려던 방으로 이어갈 수 있도록 입장 코드를 임시 보관한다.
+ */
+export const savePendingJoinCode = (code: string): void => {
+  sessionStorage.setItem(PENDING_JOIN_CODE_KEY, code);
+};
+
+export const consumePendingJoinCode = (): string | null => {
+  const code = sessionStorage.getItem(PENDING_JOIN_CODE_KEY);
+  if (code) {
+    sessionStorage.removeItem(PENDING_JOIN_CODE_KEY);
+  }
+  return code;
+};

--- a/src/pages/JoinRoomPage.tsx
+++ b/src/pages/JoinRoomPage.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import { api } from '@/lib/api';
+import { savePendingJoinCode } from '@/lib/pendingJoinCode';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Loader2 } from 'lucide-react';
+
+const JoinRoomPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { isAuthenticated, loading } = useAuth();
+  const [isJoining, setIsJoining] = useState(false);
+  const [error, setError] = useState('');
+
+  const code = (searchParams.get('code') ?? '').trim().toUpperCase();
+
+  useEffect(() => {
+    if (loading || isAuthenticated) return;
+    if (code) {
+      savePendingJoinCode(code);
+    }
+    navigate('/login', { replace: true });
+  }, [loading, isAuthenticated, code, navigate]);
+
+  const handleJoin = async () => {
+    if (!code) return;
+    setIsJoining(true);
+    setError('');
+    try {
+      await api.joinWorkoutRoomByCode(code);
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '방에 입장할 수 없습니다.');
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  if (loading || !isAuthenticated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!code) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle>초대 코드가 없어요</CardTitle>
+            <CardDescription>공유받은 링크에 입장 코드가 포함되어 있는지 확인해주세요.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link to="/dashboard">
+              <Button className="w-full">대시보드로 이동</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>운동방 초대</CardTitle>
+          <CardDescription>
+            입장 코드 <span className="font-mono font-semibold">{code}</span>로 운동방에 참여할까요?
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <Button className="w-full" onClick={handleJoin} disabled={isJoining}>
+            {isJoining && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            참여하기
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default JoinRoomPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -9,6 +9,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { consumePendingJoinCode } from '@/lib/pendingJoinCode';
 
 const SAVED_EMAIL_KEY = 'saved_email';
 
@@ -61,7 +62,13 @@ const koreanToEnglish = (text: string): string => {
 };
 
   if (isAuthenticated) {
-    return <Navigate to="/dashboard" replace />;
+    const pendingJoinCode = consumePendingJoinCode();
+    return (
+      <Navigate
+        to={pendingJoinCode ? `/join?code=${pendingJoinCode}` : '/dashboard'}
+        replace
+      />
+    );
   }
 
   type SocialProvider = 'google' | 'kakao' | 'naver';

--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
+import { consumePendingJoinCode } from '@/lib/pendingJoinCode';
 
 const OAuthCallbackPage = () => {
   const [searchParams] = useSearchParams();
@@ -26,7 +27,8 @@ const OAuthCallbackPage = () => {
     const handleSocialCallback = async () => {
       try {
         await socialLogin(accessToken, refreshToken);
-        navigate('/dashboard', { replace: true });
+        const pendingJoinCode = consumePendingJoinCode();
+        navigate(pendingJoinCode ? `/join?code=${pendingJoinCode}` : '/dashboard', { replace: true });
       } catch (error) {
         toast({
           title: '소셜 로그인에 실패했어요.',


### PR DESCRIPTION
Closes #134

## Description

운동방 초대를 카카오톡으로 바로 공유할 수 있는 딥링크 기능을 추가했습니다.

- 운동방 코드 화면에 **카카오톡으로 초대** 버튼 추가 (`Kakao.Share.sendDefault`)
- `/join?code=XXXX` 딥링크 랜딩 페이지 추가: 로그인 상태면 바로 참여 확인, 비로그인 상태면 로그인(이메일/비밀번호, 소셜 모두) 후 원래 참여하려던 방으로 자동 이어감
- `VITE_KAKAO_JS_KEY` 미설정 시 카카오 버튼은 숨겨지고 "초대 링크 복사" 버튼으로 자동 대체

## 변경 사항

- `src/lib/kakao.ts`: 카카오 SDK 동적 로드 + 초대 공유 함수
- `src/hooks/useKakaoShare.ts`: 공유 로딩/에러 상태 관리 훅
- `src/lib/pendingJoinCode.ts`: 로그인 전후 초대 코드 유지(sessionStorage)
- `src/pages/JoinRoomPage.tsx`: `/join` 딥링크 랜딩 페이지
- `RoomCodeSection`, `MyWorkoutRoom`, `LoginPage`, `OAuthCallbackPage`, `App.tsx`: 신규 기능 연동
- `CLAUDE.md`: `VITE_KAKAO_JS_KEY` 환경 변수 문서화

## 배포 전 확인 필요

- [Kakao Developers](https://developers.kakao.com)에 앱 등록 후 사용 도메인을 JavaScript SDK 허용 도메인에 추가하고, `VITE_KAKAO_JS_KEY`를 배포 환경 변수로 설정해야 카카오 공유 버튼이 활성화됩니다. 미설정 시에도 "초대 링크 복사" 버튼으로 정상 동작합니다.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [ ] 실제 브라우저에서 카카오 공유 및 `/join` 딥링크 동작 확인 (Kakao JS 키 등록 후)