### PR TITLE
fix: 이미지 확대 캐러셀 스와이프 시 화면이 튀는 문제 수정

### DIFF
--- a/src/components/MemberStatus.tsx
+++ b/src/components/MemberStatus.tsx
@@ -1,5 +1,5 @@
 import { RestInfo, RoomMember } from "@/types";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
@@ -16,10 +16,26 @@ const RECENT_WORKOUTS_LIMIT = 7;
 export const MemberStatus = ({ currentWorkoutRoom, today }) => {
     const weeklyGoal = currentWorkoutRoom.workoutRoomInfo.minWeeklyWorkouts;
     const [zoomImageUrls, setZoomImageUrls] = useState<string[] | null>(null);
+    // 다이얼로그를 열 때 한 번만 정해지는 시작 인덱스. 캐러셀을 넘겨도 바뀌지 않아야 한다.
+    const [zoomStartIndex, setZoomStartIndex] = useState<number>(0);
+    // 현재 보고 있는 인덱스. "2 / 3" 카운터 표시 전용.
     const [zoomImageIndex, setZoomImageIndex] = useState<number>(0);
     const [carouselApi, setCarouselApi] = useState<CarouselApi>();
     const [selectedMember, setSelectedMember] = useState<RoomMember | null>(null);
-  
+
+    const handleZoomImages = useCallback((urls: string[], index: number) => {
+      setZoomStartIndex(index);
+      setZoomImageIndex(index);
+      setZoomImageUrls(urls);
+    }, []);
+
+    // opts를 매 렌더마다 새 객체로 넘기면 embla가 옵션 변경으로 보고 reInit한다.
+    // startIndex에 현재 인덱스를 물리면 슬라이드를 넘길 때마다 캐러셀이 재초기화되어 화면이 튄다.
+    const zoomCarouselOpts = useMemo(
+      () => ({ startIndex: zoomStartIndex, loop: true }),
+      [zoomStartIndex]
+    );
+
     // 특정 멤버가 오늘 휴식일인지 확인하는 함수
     const isMemberRestToday = (member: RoomMember) => {
       return member.restInfoList.some((restInfo: RestInfo) => {
@@ -147,10 +163,7 @@ export const MemberStatus = ({ currentWorkoutRoom, today }) => {
                                       src={imageUrls[0]}
                                       alt="운동 인증 사진"
                                       className='max-w-xs max-h-60 rounded cursor-zoom-in'
-                                      onClick={() => {
-                                        setZoomImageUrls(imageUrls);
-                                        setZoomImageIndex(0);
-                                      }}
+                                      onClick={() => handleZoomImages(imageUrls, 0)}
                                     />
                                     <div className="text-center text-xs text-muted-foreground mt-1">
                                       클릭하여 확대
@@ -168,10 +181,7 @@ export const MemberStatus = ({ currentWorkoutRoom, today }) => {
                                                 src={url}
                                                 alt={`운동 인증 사진 ${idx + 1}`}
                                                 className='w-full h-32 sm:h-40 object-cover rounded cursor-zoom-in'
-                                                onClick={() => {
-                                                  setZoomImageUrls(imageUrls);
-                                                  setZoomImageIndex(idx);
-                                                }}
+                                                onClick={() => handleZoomImages(imageUrls, idx)}
                                               />
                                             </CarouselItem>
                                           ))}
@@ -257,13 +267,10 @@ export const MemberStatus = ({ currentWorkoutRoom, today }) => {
                       className="w-full h-auto max-h-[90vh] object-contain rounded" 
                     />
                   ) : (
-                    <Carousel 
-                      className="w-full" 
+                    <Carousel
+                      className="w-full"
                       setApi={setCarouselApi}
-                      opts={{ 
-                        startIndex: zoomImageIndex,
-                        loop: true 
-                      }}
+                      opts={zoomCarouselOpts}
                     >
                       <CarouselContent>
                         {zoomImageUrls.map((url, idx) => (

--- a/src/components/MyWorkoutRoom.tsx
+++ b/src/components/MyWorkoutRoom.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { format } from 'date-fns';
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { ko } from 'date-fns/locale';
@@ -15,9 +15,25 @@ import { Clock } from "lucide-react";
 export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRegenerateEntryCode, isRegeneratingEntryCode, onOpenPenaltySchedule }) => {
     const [date, setDate] = useState<Date | undefined>(new Date());
     const [zoomImageUrls, setZoomImageUrls] = useState<string[] | null>(null);
+    // 다이얼로그를 열 때 한 번만 정해지는 시작 인덱스. 캐러셀을 넘겨도 바뀌지 않아야 한다.
+    const [zoomStartIndex, setZoomStartIndex] = useState<number>(0);
+    // 현재 보고 있는 인덱스. "2 / 3" 카운터 표시 전용.
     const [zoomImageIndex, setZoomImageIndex] = useState<number>(0);
     const [carouselApi, setCarouselApi] = useState<CarouselApi>();
-    
+
+    const handleZoomImages = useCallback((urls: string[], index: number) => {
+      setZoomStartIndex(index);
+      setZoomImageIndex(index);
+      setZoomImageUrls(urls);
+    }, []);
+
+    // opts를 매 렌더마다 새 객체로 넘기면 embla가 옵션 변경으로 보고 reInit한다.
+    // startIndex에 현재 인덱스를 물리면 슬라이드를 넘길 때마다 캐러셀이 재초기화되어 화면이 튄다.
+    const zoomCarouselOpts = useMemo(
+      () => ({ startIndex: zoomStartIndex, loop: true }),
+      [zoomStartIndex]
+    );
+
     // 순위용 정렬된 멤버 목록 (원본 배열은 변경하지 않음)
     const sortedMembersByWorkouts = [...currentWorkoutRoom.workoutRoomMembers]
       .sort((a, b) => b.totalWorkouts - a.totalWorkouts);
@@ -140,10 +156,7 @@ export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRege
                                       src={imageUrls[0]}
                                       alt="운동 인증 사진"
                                       className="max-w-xs max-h-60 rounded cursor-zoom-in"
-                                      onClick={() => {
-                                        setZoomImageUrls(imageUrls);
-                                        setZoomImageIndex(0);
-                                      }}
+                                      onClick={() => handleZoomImages(imageUrls, 0)}
                                     />
                                    <div className="text-center text-xs text-muted-foreground mt-1">
                                       클릭하여 확대
@@ -161,10 +174,7 @@ export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRege
                                                 src={url}
                                                 alt={`운동 인증 사진 ${idx + 1}`}
                                                 className="w-full h-32 sm:h-40 object-cover rounded cursor-zoom-in"
-                                                onClick={() => {
-                                                  setZoomImageUrls(imageUrls);
-                                                  setZoomImageIndex(idx);
-                                                }}
+                                                onClick={() => handleZoomImages(imageUrls, idx)}
                                               />
                                             </CarouselItem>
                                           ))}
@@ -367,13 +377,10 @@ export const MyWorkoutRoom = ( {currentWorkoutRoom, today, currentMember, onRege
                     className="w-full h-auto max-h-[90vh] object-contain rounded" 
                   />
                 ) : (
-                  <Carousel 
-                    className="w-full" 
+                  <Carousel
+                    className="w-full"
                     setApi={setCarouselApi}
-                    opts={{ 
-                      startIndex: zoomImageIndex,
-                      loop: true 
-                    }}
+                    opts={zoomCarouselOpts}
                   >
                     <CarouselContent>
                       {zoomImageUrls.map((url, idx) => (

--- a/src/components/WorkoutFeedSection.tsx
+++ b/src/components/WorkoutFeedSection.tsx
@@ -24,8 +24,24 @@ export const WorkoutFeedSection = ({ feed, onFeedUpdate, initialIsLastPage = fal
   const [hasMore, setHasMore] = useState(!initialIsLastPage);
   const [selectedPeriod, setSelectedPeriod] = useState<WorkoutFeedPeriod>('ALL');
   const [zoomImageUrls, setZoomImageUrls] = useState<string[] | null>(null);
+  // 다이얼로그를 열 때 한 번만 정해지는 시작 인덱스. 캐러셀을 넘겨도 바뀌지 않아야 한다.
+  const [zoomStartIndex, setZoomStartIndex] = useState<number>(0);
+  // 현재 보고 있는 인덱스. "2 / 3" 카운터 표시 전용.
   const [zoomImageIndex, setZoomImageIndex] = useState<number>(0);
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
+
+  const handleZoomImages = useCallback((urls: string[], index: number) => {
+    setZoomStartIndex(index);
+    setZoomImageIndex(index);
+    setZoomImageUrls(urls);
+  }, []);
+
+  // opts를 매 렌더마다 새 객체로 넘기면 embla가 옵션 변경으로 보고 reInit한다.
+  // startIndex에 현재 인덱스를 물리면 슬라이드를 넘길 때마다 캐러셀이 재초기화되어 화면이 튄다.
+  const zoomCarouselOpts = useMemo(
+    () => ({ startIndex: zoomStartIndex, loop: true }),
+    [zoomStartIndex]
+  );
 
   // feed가 배열이 아닐 경우 빈 배열로 처리
   const safeFeed = useMemo<WorkoutFeedItem[]>(() => {
@@ -190,10 +206,7 @@ export const WorkoutFeedSection = ({ feed, onFeedUpdate, initialIsLastPage = fal
                             src={imageUrls[0]}
                             alt={`${workoutTypes.join(', ')} 운동`}
                             className="w-full h-64 sm:h-80 object-cover cursor-zoom-in"
-                            onClick={() => {
-                              setZoomImageUrls(imageUrls);
-                              setZoomImageIndex(0);
-                            }}
+                            onClick={() => handleZoomImages(imageUrls, 0)}
                           />
                         ) : (
                           <Carousel className="w-full">
@@ -204,10 +217,7 @@ export const WorkoutFeedSection = ({ feed, onFeedUpdate, initialIsLastPage = fal
                                     src={url}
                                     alt={`${workoutTypes.join(', ')} 운동 ${idx + 1}`}
                                     className="w-full h-64 sm:h-80 object-cover cursor-zoom-in"
-                                    onClick={() => {
-                                      setZoomImageUrls(imageUrls);
-                                      setZoomImageIndex(idx);
-                                    }}
+                                    onClick={() => handleZoomImages(imageUrls, idx)}
                                   />
                                 </CarouselItem>
                               ))}
@@ -285,13 +295,10 @@ export const WorkoutFeedSection = ({ feed, onFeedUpdate, initialIsLastPage = fal
                   className="w-full h-auto max-h-[90vh] object-contain rounded" 
                 />
               ) : (
-                <Carousel 
-                  className="w-full" 
+                <Carousel
+                  className="w-full"
                   setApi={setCarouselApi}
-                  opts={{ 
-                    startIndex: zoomImageIndex,
-                    loop: true 
-                  }}
+                  opts={zoomCarouselOpts}
                 >
                   <CarouselContent>
                     {zoomImageUrls.map((url, idx) => (

--- a/src/components/admin/AdminRoomMembersTab.tsx
+++ b/src/components/admin/AdminRoomMembersTab.tsx
@@ -296,6 +296,9 @@ export const AdminRoomMembersTab = ({
   const isMobile = useIsMobile();
   const [selectedMember, setSelectedMember] = useState<RoomMember | null>(null);
   const [zoomImageUrls, setZoomImageUrls] = useState<string[] | null>(null);
+  // 다이얼로그를 열 때 한 번만 정해지는 시작 인덱스. 캐러셀을 넘겨도 바뀌지 않아야 한다.
+  const [zoomStartIndex, setZoomStartIndex] = useState(0);
+  // 현재 보고 있는 인덱스. "2 / 3" 카운터 표시 전용.
   const [zoomImageIndex, setZoomImageIndex] = useState(0);
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
 
@@ -313,9 +316,17 @@ export const AdminRoomMembersTab = ({
   };
 
   const handleZoomImages = (urls: string[], index = 0) => {
-    setZoomImageUrls(urls);
+    setZoomStartIndex(index);
     setZoomImageIndex(index);
+    setZoomImageUrls(urls);
   };
+
+  // opts를 매 렌더마다 새 객체로 넘기면 embla가 옵션 변경으로 보고 reInit한다.
+  // startIndex에 현재 인덱스를 물리면 슬라이드를 넘길 때마다 캐러셀이 재초기화되어 화면이 튄다.
+  const zoomCarouselOpts = useMemo(
+    () => ({ startIndex: zoomStartIndex, loop: true }),
+    [zoomStartIndex],
+  );
 
   useEffect(() => {
     if (!carouselApi) return;
@@ -511,10 +522,7 @@ export const AdminRoomMembersTab = ({
                 <Carousel
                   className="w-full px-12"
                   setApi={setCarouselApi}
-                  opts={{
-                    startIndex: zoomImageIndex,
-                    loop: true,
-                  }}
+                  opts={zoomCarouselOpts}
                 >
                   <CarouselContent>
                     {zoomImageUrls.map((url, idx) => (

--- a/src/components/landing/MobileCTABar.tsx
+++ b/src/components/landing/MobileCTABar.tsx
@@ -27,7 +27,7 @@ export const MobileCTABar = ({ onNavigate }: MobileCTABarProps) => {
             onClick={() => onNavigate('/login')}
             aria-label="무료로 운동방 만들기"
           >
-            무료로 방 만들기
+            로그인 하기
           </Button>
         </HeroRevealItem>
       </div>

--- a/src/test/zoomCarousel.test.tsx
+++ b/src/test/zoomCarousel.test.tsx
@@ -1,0 +1,141 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkoutFeedItem } from '@/types';
+
+/**
+ * 이미지 확대 다이얼로그의 캐러셀 회귀 테스트.
+ *
+ * 과거 버그: `opts={{ startIndex: zoomImageIndex, loop: true }}` 처럼 현재 선택 인덱스를
+ * 그대로 startIndex 에 물려 두면, 슬라이드를 넘길 때마다(select 이벤트 → setState)
+ * embla 가 옵션 변경으로 인식해 캐러셀 전체를 reInit 한다. 그 결과 스와이프할 때마다
+ * 캐러셀이 재초기화되면서 화면이 크게 튀었다.
+ *
+ * startIndex 는 다이얼로그를 여는 시점에만 결정되어야 하며, 이후 슬라이드 이동에는
+ * 반응하지 않아야 한다.
+ */
+
+type EmblaSelectHandler = () => void;
+
+const carouselOptsLog: unknown[] = [];
+let selectHandlers: EmblaSelectHandler[] = [];
+let currentSnap = 0;
+let lastOpts: unknown;
+
+const fakeApi = {
+  selectedScrollSnap: () => currentSnap,
+  on: (event: string, handler: EmblaSelectHandler) => {
+    if (event === 'select') selectHandlers.push(handler);
+  },
+  off: (event: string, handler: EmblaSelectHandler) => {
+    if (event === 'select') selectHandlers = selectHandlers.filter((h) => h !== handler);
+  },
+};
+
+vi.mock('@/components/ui/carousel', () => ({
+  Carousel: ({
+    opts,
+    setApi,
+    children,
+  }: {
+    opts?: unknown;
+    setApi?: (api: unknown) => void;
+    children?: ReactNode;
+  }) => {
+    // 피드 목록의 캐러셀은 setApi 를 넘기지 않는다. 확대 다이얼로그 캐러셀만 추적한다.
+    if (setApi) {
+      // 실제 embla 는 새 옵션으로 초기화될 때 startIndex 위치에서 시작한다.
+      // opts 참조가 바뀌었을 때만 반영해야 select 시뮬레이션이 리렌더에 덮어써지지 않는다.
+      if (opts !== lastOpts) {
+        lastOpts = opts;
+        currentSnap = (opts as { startIndex?: number } | undefined)?.startIndex ?? 0;
+      }
+      carouselOptsLog.push(opts);
+      setApi(fakeApi);
+    }
+    return <div data-testid="carousel">{children}</div>;
+  },
+  CarouselContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  CarouselItem: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  CarouselNext: () => <button type="button">next</button>,
+  CarouselPrevious: () => <button type="button">prev</button>,
+}));
+
+// mock 은 호이스팅되므로 컴포넌트는 mock 선언 이후에 가져온다.
+const { WorkoutFeedSection } = await import('@/components/WorkoutFeedSection');
+
+// "2 / 3" 카운터는 JSX 상 텍스트 노드가 쪼개져 있어 getByText 로 잡히지 않는다.
+const readCounter = (): string | undefined =>
+  Array.from(document.querySelectorAll('div'))
+    .map((node) => node.textContent?.trim() ?? '')
+    .filter((text) => /^\d+ \/ \d+$/.test(text))
+    .at(-1);
+
+const buildFeedItem = (): WorkoutFeedItem => ({
+  id: 1,
+  workoutDate: '2026-07-20',
+  workoutTypes: ['헬스(가슴)'],
+  duration: 60,
+  imageUrls: ['a.jpg', 'b.jpg', 'c.jpg'],
+  likes: 0,
+  comments: 0,
+  isLiked: false,
+  createdAt: '2026-07-20T10:00:00',
+});
+
+describe('이미지 확대 캐러셀', () => {
+  beforeEach(() => {
+    carouselOptsLog.length = 0;
+    selectHandlers = [];
+    currentSnap = 0;
+    lastOpts = undefined;
+  });
+
+  it('슬라이드를 넘겨도 startIndex 가 바뀌지 않아 embla 가 reInit 되지 않는다', async () => {
+    const user = userEvent.setup();
+    render(
+      <WorkoutFeedSection feed={[buildFeedItem()]} onFeedUpdate={() => {}} initialIsLastPage />,
+    );
+
+    // 두 번째 이미지를 눌러 확대 다이얼로그를 연다.
+    await user.click(screen.getByAltText('헬스(가슴) 운동 2'));
+
+    const optsAfterOpen = carouselOptsLog.at(-1) as { startIndex: number };
+    expect(optsAfterOpen.startIndex).toBe(1);
+    expect(readCounter()).toBe('2 / 3');
+
+    // 캐러셀에서 세 번째 슬라이드로 이동한 상황을 재현한다.
+    const optsCountBefore = carouselOptsLog.length;
+    currentSnap = 2;
+    await act(async () => {
+      selectHandlers.forEach((handler) => handler());
+    });
+
+    // 카운터는 따라와야 한다.
+    expect(readCounter()).toBe('3 / 3');
+
+    // 리렌더가 발생했더라도 startIndex 는 열 때 값(1)을 유지해야 한다.
+    expect(carouselOptsLog.length).toBeGreaterThan(optsCountBefore);
+    for (const opts of carouselOptsLog.slice(optsCountBefore)) {
+      expect((opts as { startIndex: number }).startIndex).toBe(1);
+    }
+
+    // opts 객체 자체도 동일 참조여야 embla 가 옵션 변경으로 오인하지 않는다.
+    expect(carouselOptsLog.at(-1)).toBe(optsAfterOpen);
+  });
+
+  it('다른 기록의 이미지를 열면 새로운 startIndex 가 적용된다', async () => {
+    const user = userEvent.setup();
+    render(
+      <WorkoutFeedSection feed={[buildFeedItem()]} onFeedUpdate={() => {}} initialIsLastPage />,
+    );
+
+    await user.click(screen.getByAltText('헬스(가슴) 운동 1'));
+    expect((carouselOptsLog.at(-1) as { startIndex: number }).startIndex).toBe(0);
+
+    await user.keyboard('{Escape}');
+    await user.click(screen.getByAltText('헬스(가슴) 운동 3'));
+    expect((carouselOptsLog.at(-1) as { startIndex: number }).startIndex).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #139

## Description

운동 인증 사진 확대 다이얼로그에서 슬라이드를 넘길 때마다 화면이 크게 튀던 문제를 수정했습니다.

### 원인

확대 다이얼로그 캐러셀이 `opts={{ startIndex: zoomImageIndex, loop: true }}` 형태로 옵션을 넘기고 있었습니다.

1. `opts` 가 매 렌더마다 새 객체 리터럴로 생성되어 embla 가 옵션 변경으로 인식 → `reInit`
2. `startIndex` 에 현재 선택 인덱스를 물려 둬서, 슬라이드 이동(`select` → `setZoomImageIndex`) 때마다 값이 바뀜

두 조건이 겹쳐 스와이프할 때마다 캐러셀 전체가 재초기화되었습니다.

### 변경 내용

- `startIndex` 전용 상태 `zoomStartIndex` 를 분리 — 다이얼로그를 여는 시점에만 결정되고 이후 슬라이드 이동에 반응하지 않습니다.
- 기존 `zoomImageIndex` 는 "2 / 3" 카운터 표시 전용으로 한정했습니다.
- `opts` 를 `useMemo` 로 감싸 `zoomStartIndex` 가 바뀔 때만 새 참조가 생기도록 했습니다.
- 이미지 클릭 핸들러를 `handleZoomImages(urls, index)` 로 통일했습니다.

적용 컴포넌트: `MemberStatus`, `MyWorkoutRoom`, `WorkoutFeedSection`, `admin/AdminRoomMembersTab`

### 함께 처리

- 랜딩 모바일 CTA 버튼 문구를 "무료로 방 만들기" → "로그인 하기" 로 변경 (`MobileCTABar.tsx`)

## 테스트

- `src/test/zoomCarousel.test.tsx` 회귀 테스트 신규 추가 (2건 통과)
  - 슬라이드를 넘겨도 `startIndex` 와 `opts` 참조가 유지되는지 검증
  - 다른 기록의 이미지를 새로 열면 새 `startIndex` 가 적용되는지 검증
- `npm run lint` 통과

> 참고: `src/pages/CreateRoomPage.test.tsx` 2건이 실패하지만 이번 변경과 무관한 기존 실패입니다(수정 파일과 겹치지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
