### PR TITLE
fix: 모바일 주식 현황에서 종목명이 말줄임(...)으로 잘리는 문제 개선

### DIFF
--- a/src/components/stock/StockHoldingListItem.tsx
+++ b/src/components/stock/StockHoldingListItem.tsx
@@ -246,43 +246,53 @@ const StockHoldingListItem: React.FC<StockHoldingListItemProps> = ({
           tabIndex={0}
           onClick={() => setExpanded(!expanded)}
           onKeyDown={(e) => e.key === 'Enter' && setExpanded(!expanded)}
-          className="flex items-center gap-3 p-4 min-h-[56px] active:bg-gray-50 dark:active:bg-gray-800/70"
+          className="flex items-start gap-2.5 p-4 min-h-[56px] active:bg-gray-50 dark:active:bg-gray-800/70"
         >
-          <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center text-sm font-semibold text-white shrink-0">
+          <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
             {getInitials(holding.stockName)}
           </div>
           <div className="flex-1 min-w-0">
-            <div className="font-semibold text-gray-900 dark:text-gray-100 truncate">
+            <div className="font-semibold text-gray-900 dark:text-gray-100 break-words leading-snug">
               {holding.stockName}
             </div>
             {displayMode === 'currentPrice' ? (
-              <div className="text-sm text-gray-600 dark:text-gray-400">
+              <div className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
                 내 평균 {formatCurrency(holding.averagePrice)}
               </div>
             ) : (
-              <div className="text-sm text-gray-600 dark:text-gray-400">
+              <div className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
                 {holding.quantity.toLocaleString(undefined, { maximumFractionDigits: 6 })}주
               </div>
             )}
           </div>
-          <div className="text-right shrink-0">
+          <div className="text-right shrink-0 tabular-nums">
             {displayMode === 'currentPrice' ? (
               <>
-                <div className="font-semibold text-gray-900 dark:text-gray-100">
+                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 whitespace-nowrap leading-snug">
                   {formatCurrency(holding.currentPrice)}
                 </div>
                 {dayChangeRate != null && (
-                  <div className={cn('text-sm font-medium', getProfitLossColor(dayChangeRate))}>
+                  <div
+                    className={cn(
+                      'text-xs font-medium whitespace-nowrap mt-0.5',
+                      getProfitLossColor(dayChangeRate)
+                    )}
+                  >
                     {dayChangeDisplay}
                   </div>
                 )}
               </>
-            ) : ( 
+            ) : (
               <>
-                <div className="font-semibold text-gray-900 dark:text-gray-100">
+                <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 whitespace-nowrap leading-snug">
                   {formatCurrency(holding.marketValue)}
                 </div>
-                <div className={cn('text-sm font-medium', getProfitLossColor(holding.profitLoss))}>
+                <div
+                  className={cn(
+                    'text-xs font-medium whitespace-nowrap mt-0.5',
+                    getProfitLossColor(holding.profitLoss)
+                  )}
+                >
                   {holding.profitLoss >= 0 ? '+' : ''}
                   {formatCurrency(holding.profitLoss)} ({formatPercentage(holding.profitLossRate)})
                 </div>
@@ -290,9 +300,9 @@ const StockHoldingListItem: React.FC<StockHoldingListItemProps> = ({
             )}
           </div>
           {expanded ? (
-            <ChevronUp className="h-5 w-5 text-gray-400 shrink-0" />
+            <ChevronUp className="h-4 w-4 text-gray-400 shrink-0 mt-1" />
           ) : (
-            <ChevronDown className="h-5 w-5 text-gray-400 shrink-0" />
+            <ChevronDown className="h-4 w-4 text-gray-400 shrink-0 mt-1" />
           )}
         </div>
         {expanded && detailSection}
@@ -313,8 +323,8 @@ const StockHoldingListItem: React.FC<StockHoldingListItemProps> = ({
           <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center text-sm font-semibold text-white shrink-0">
             {getInitials(holding.stockName)}
           </div>
-          <div>
-            <div className="font-semibold text-gray-900 dark:text-gray-100">
+          <div className="min-w-0">
+            <div className="font-semibold text-gray-900 dark:text-gray-100 break-words">
               {holding.stockName}
             </div>
             {displayMode === 'currentPrice' ? (
@@ -328,7 +338,7 @@ const StockHoldingListItem: React.FC<StockHoldingListItemProps> = ({
             )}
           </div>
         </div>
-        <div className="flex items-center gap-6">
+        <div className="flex items-center gap-6 shrink-0">
           {displayMode === 'currentPrice' ? (
             <>
               <div className="text-right">

--- a/src/components/stock/StockProfitTab.tsx
+++ b/src/components/stock/StockProfitTab.tsx
@@ -385,12 +385,12 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
                               dark ? 'border border-gray-700' : 'border border-gray-200'
                             )}
                           >
-                            <div className="flex items-center gap-3">
-                              <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center text-sm font-semibold text-white">
+                            <div className="flex items-center gap-3 min-w-0">
+                              <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
                                 {getInitials(t.stockName)}
                               </div>
-                              <div>
-                                <div className="font-medium text-gray-900 dark:text-gray-100">
+                              <div className="min-w-0">
+                                <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
                                   {t.stockName}
                                 </div>
                                 <div className={cn('text-sm', getProfitLossColor(t.profitLoss))}>
@@ -421,12 +421,14 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
                     dark ? 'border border-gray-700' : 'border border-gray-200'
                   )}
                 >
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center text-sm font-semibold text-white">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
                       {getInitials(s.name)}
                     </div>
-                    <div>
-                      <div className="font-medium text-gray-900 dark:text-gray-100">{s.name}</div>
+                    <div className="min-w-0">
+                      <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
+                        {s.name}
+                      </div>
                       <div className={cn('text-sm', getProfitLossColor(s.profit))}>
                         {formatCurrency(s.profit)}
                         {s.count === 1 && ` (${formatPercentage(s.rate)})`}
@@ -499,12 +501,12 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
                               dark ? 'border border-gray-700' : 'border border-gray-200'
                             )}
                           >
-                            <div className="flex items-center gap-3">
-                              <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center text-sm font-semibold text-white">
+                            <div className="flex items-center gap-3 min-w-0">
+                              <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
                                 {getInitials(t.stockName)}
                               </div>
-                              <div>
-                                <div className="font-medium text-gray-900 dark:text-gray-100">
+                              <div className="min-w-0">
+                                <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
                                   {t.stockName}
                                 </div>
                                 <div className={cn('text-sm', getProfitLossColor(-t.fee))}>
@@ -535,12 +537,14 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
                     dark ? 'border border-gray-700' : 'border border-gray-200'
                   )}
                 >
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center text-sm font-semibold text-white">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
                       {getInitials(s.name)}
                     </div>
-                    <div>
-                      <div className="font-medium text-gray-900 dark:text-gray-100">{s.name}</div>
+                    <div className="min-w-0">
+                      <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
+                        {s.name}
+                      </div>
                       <div className={cn('text-sm', getProfitLossColor(-s.fee))}>
                         -{formatCurrency(s.fee)}
                       </div>
@@ -612,12 +616,12 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
                               dark ? 'border border-gray-700' : 'border border-gray-200'
                             )}
                           >
-                            <div className="flex items-center gap-3">
-                              <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center text-sm font-semibold text-white">
+                            <div className="flex items-center gap-3 min-w-0">
+                              <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
                                 {getInitials(t.stockName)}
                               </div>
-                              <div>
-                                <div className="font-medium text-gray-900 dark:text-gray-100">
+                              <div className="min-w-0">
+                                <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
                                   {t.stockName}
                                 </div>
                                 <div className={cn('text-sm', getProfitLossColor(-t.tax))}>
@@ -648,12 +652,14 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
                     dark ? 'border border-gray-700' : 'border border-gray-200'
                   )}
                 >
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-full bg-gray-600 flex items-center justify-center text-sm font-semibold text-white">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
                       {getInitials(s.name)}
                     </div>
-                    <div>
-                      <div className="font-medium text-gray-900 dark:text-gray-100">{s.name}</div>
+                    <div className="min-w-0">
+                      <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
+                        {s.name}
+                      </div>
                       <div className={cn('text-sm', getProfitLossColor(-s.tax))}>
                         -{formatCurrency(s.tax)}
                       </div>


### PR DESCRIPTION
Closes #141

## Description

모바일 주식 현황 목록에서 종목 이름이 `...`으로 잘려 보이지 않던 문제를 수정했다.

### StockHoldingListItem.tsx (모바일 카드)

- 종목명의 `truncate`를 제거하고 `break-words leading-snug`로 변경해 두 줄 이상 자연 줄바꿈되며 이름 전체가 노출된다. (한글은 글자 단위, 영문 티커는 `break-words`로 처리)
- 이름이 여러 줄일 때 금액/셰브론이 상단 기준으로 정렬되도록 행 정렬을 `items-center` → `items-start`로 변경했다.
- 아바타 40→36px, gap 12→10px, 셰브론 20→16px, 보조 텍스트를 `text-xs`로 낮춰 종목명 영역에 약 40px를 추가 확보했다.
- 금액 컬럼에 `whitespace-nowrap tabular-nums`를 적용해 숫자 폭이 흔들리지 않도록 고정했다.

### StockHoldingListItem.tsx (데스크톱 행)

- 이름 컨테이너에 `min-w-0 break-words`, 우측 값 영역에 `shrink-0`을 추가해 긴 이름에서 레이아웃이 밀리지 않게 했다.

### StockProfitTab.tsx

- 수익분석 탭의 일별/종목별 목록 6곳에 컨테이너 `min-w-0`, 이름 `break-words`, 아바타 `shrink-0`(36px)을 적용했다. 해당 목록에는 `truncate`가 없었지만 `min-w-0`이 없어 긴 이름이 카드 밖으로 넘칠 수 있는 상태였다.

## 검증

- `npx eslint src/components/stock/StockHoldingListItem.tsx src/components/stock/StockProfitTab.tsx --quiet` 통과
- 스타일 변경만 있으며 로직/데이터 흐름 변경은 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)