### PR TITLE
PWA 설치 배너에 '오늘 하루/일주일 동안 보지 않기' 스누즈 옵션 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,13 @@ const AppRoutes = () => (
 
 const App = () => {
   const { needRefresh, handleUpdate, dismiss } = usePwaUpdater();
-  const { visible: installBannerVisible, platform: installPlatform, promptInstall, dismiss: dismissInstall } = usePwaInstallPrompt();
+  const {
+    visible: installBannerVisible,
+    platform: installPlatform,
+    promptInstall,
+    dismiss: dismissInstall,
+    snooze: snoozeInstall,
+  } = usePwaInstallPrompt();
   const { isKakaoInApp, showFallbackGuide } = useKakaoInAppBrowserExit();
   const [kakaoNoticeDismissed, setKakaoNoticeDismissed] = useState(false);
 
@@ -133,6 +139,7 @@ const App = () => {
           platform={installPlatform}
           onInstall={promptInstall}
           onClose={dismissInstall}
+          onSnooze={snoozeInstall}
         />
         <KakaoInAppBrowserNotice
           visible={isKakaoInApp && showFallbackGuide && !kakaoNoticeDismissed}

--- a/src/components/common/PwaInstallBanner.tsx
+++ b/src/components/common/PwaInstallBanner.tsx
@@ -1,16 +1,17 @@
 import type { FC } from 'react';
 import { Download, Share2, SquarePlus, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import type { PwaInstallPlatform } from '@/hooks/usePwaInstallPrompt';
+import type { PwaInstallPlatform, PwaInstallSnoozeDuration } from '@/hooks/usePwaInstallPrompt';
 
 interface PwaInstallBannerProps {
   visible: boolean;
   platform: PwaInstallPlatform | null;
   onInstall: () => void;
   onClose: () => void;
+  onSnooze: (duration: PwaInstallSnoozeDuration) => void;
 }
 
-export const PwaInstallBanner: FC<PwaInstallBannerProps> = ({ visible, platform, onInstall, onClose }) => {
+export const PwaInstallBanner: FC<PwaInstallBannerProps> = ({ visible, platform, onInstall, onClose, onSnooze }) => {
   if (!visible || !platform) {
     return null;
   }
@@ -46,21 +47,36 @@ export const PwaInstallBanner: FC<PwaInstallBannerProps> = ({ visible, platform,
             <X className="h-4 w-4" />
           </button>
         </div>
-        <div className="flex justify-end gap-2 border-t px-4 py-2.5 sm:px-5">
-          <Button variant="ghost" size="sm" onClick={onClose}>
-            나중에
-          </Button>
+        <div className="flex flex-col gap-2 border-t px-4 py-2.5 sm:px-5">
           {platform === 'android' && (
-            <Button size="sm" onClick={onInstall}>
+            <Button size="sm" className="w-full" onClick={onInstall}>
               <Download className="h-4 w-4" />
               앱 설치하기
             </Button>
           )}
           {platform === 'ios' && (
-            <Button size="sm" onClick={onClose}>
+            <Button size="sm" className="w-full" onClick={onClose}>
               확인했어요
             </Button>
           )}
+          <div className="flex justify-between gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex-1 text-xs text-muted-foreground"
+              onClick={() => onSnooze('today')}
+            >
+              오늘 하루 보지 않기
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="flex-1 text-xs text-muted-foreground"
+              onClick={() => onSnooze('week')}
+            >
+              일주일 동안 보지 않기
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/hooks/usePwaInstallPrompt.ts
+++ b/src/hooks/usePwaInstallPrompt.ts
@@ -7,6 +7,40 @@ interface BeforeInstallPromptEvent extends Event {
 
 export type PwaInstallPlatform = 'android' | 'ios';
 
+export type PwaInstallSnoozeDuration = 'today' | 'week';
+
+const SNOOZE_STORAGE_KEY = 'pwa-install-snooze-until';
+
+// 스누즈 만료 시각(ms)을 반환한다. '오늘'은 오늘 자정까지, '일주일'은 7일 뒤까지 배너를 숨긴다.
+const getSnoozeUntil = (duration: PwaInstallSnoozeDuration): number => {
+  if (duration === 'today') {
+    const endOfToday = new Date();
+    endOfToday.setHours(23, 59, 59, 999);
+    return endOfToday.getTime();
+  }
+  return Date.now() + 7 * 24 * 60 * 60 * 1000;
+};
+
+const isSnoozed = (): boolean => {
+  try {
+    const raw = window.localStorage.getItem(SNOOZE_STORAGE_KEY);
+    if (!raw) {
+      return false;
+    }
+    const until = Number(raw);
+    if (Number.isNaN(until)) {
+      return false;
+    }
+    if (Date.now() >= until) {
+      window.localStorage.removeItem(SNOOZE_STORAGE_KEY);
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const isStandaloneDisplay = (): boolean =>
   window.matchMedia('(display-mode: standalone)').matches ||
   (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
@@ -24,6 +58,7 @@ interface UsePwaInstallPromptResult {
   platform: PwaInstallPlatform | null;
   promptInstall: () => void;
   dismiss: () => void;
+  snooze: (duration: PwaInstallSnoozeDuration) => void;
 }
 
 export const usePwaInstallPrompt = (): UsePwaInstallPromptResult => {
@@ -32,7 +67,7 @@ export const usePwaInstallPrompt = (): UsePwaInstallPromptResult => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    if (isStandaloneDisplay()) {
+    if (isStandaloneDisplay() || isSnoozed()) {
       return;
     }
 
@@ -68,6 +103,15 @@ export const usePwaInstallPrompt = (): UsePwaInstallPromptResult => {
     setVisible(false);
   }, []);
 
+  const snooze = useCallback((duration: PwaInstallSnoozeDuration) => {
+    try {
+      window.localStorage.setItem(SNOOZE_STORAGE_KEY, String(getSnoozeUntil(duration)));
+    } catch {
+      // localStorage 접근이 차단된 경우 무시하고 세션 동안만 숨긴다.
+    }
+    setVisible(false);
+  }, []);
+
   const promptInstall = useCallback(() => {
     if (!deferredPrompt) {
       return;
@@ -80,5 +124,5 @@ export const usePwaInstallPrompt = (): UsePwaInstallPromptResult => {
     });
   }, [deferredPrompt]);
 
-  return { visible, platform, promptInstall, dismiss };
+  return { visible, platform, promptInstall, dismiss, snooze };
 };


### PR DESCRIPTION
Closes #143

## Description

PWA 설치 안내 배너에서 사용자가 일정 기간 동안 배너를 보지 않도록 선택할 수 있는 스누즈 옵션을 추가했습니다.

### 변경 내용

- 기존 "나중에" 버튼을 **오늘 하루 보지 않기** / **일주일 동안 보지 않기** 두 옵션으로 대체
- 선택 시 `localStorage`(`pwa-install-snooze-until`)에 만료 시각 저장
  - **오늘 하루**: 오늘 자정(23:59:59.999)까지
  - **일주일**: 7일 뒤까지
- 마운트 시 만료 여부를 확인해 유효하면 배너 미노출 (만료 항목은 자동 정리)
- `localStorage` 접근 차단 환경은 `try/catch`로 예외 처리하여 세션 단위 숨김으로 폴백
- 설치 버튼(안드로이드)/"확인했어요"(iOS)를 상단 전체 너비 행으로 배치해 레이아웃 정리
- X 버튼은 기존과 동일한 세션 단위 임시 닫기 유지

### 관련 파일

- `src/hooks/usePwaInstallPrompt.ts`
- `src/components/common/PwaInstallBanner.tsx`
- `src/App.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)