### PR TITLE
운동 인증/휴식일/채팅 알림 발송을 위한 프론트엔드 수동 호출 제거

### DIFF
--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -495,17 +495,7 @@ export const ChatRoom = ({ currentWorkoutRoom }: ChatRoomProps) => {
       textareaRef.current?.focus();
     }, 0);
     setTimeout(() => api.updateLastRead(roomId), 500); // 서버 반영 시간 고려 약간의 딜레이
-
-    if (roomId) {
-      api.notifyRoomMembers(roomId, {
-        title: member.nickname + "님이 메시지를 보냈어요!",
-        body: content,
-        type: "CHAT",
-      }).catch((notifyErr) => {
-        console.warn('채팅 알림 전송 실패', notifyErr);
-      });
-    }
-  }, [input, roomId, accessToken, member.nickname]);
+  }, [input, roomId, accessToken]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // 모바일: Enter 시 기본 줄바꿈만 허용 (전송 안 함)
@@ -585,13 +575,6 @@ export const ChatRoom = ({ currentWorkoutRoom }: ChatRoomProps) => {
       });
       clearFile();
       setTimeout(() => api.updateLastRead(roomId), 500);
-      api.notifyRoomMembers(roomId, {
-        title: member.nickname + '님이 사진을 보냈어요!',
-        body: '사진',
-        type: 'CHAT',
-      }).catch((notifyErr) => {
-        console.warn('채팅 알림 전송 실패', notifyErr);
-      });
       setTimeout(() => textareaRef.current?.focus(), 0);
     } catch (err) {
       const message = err instanceof Error ? err.message : '이미지 업로드에 실패했습니다.';
@@ -599,7 +582,7 @@ export const ChatRoom = ({ currentWorkoutRoom }: ChatRoomProps) => {
     } finally {
       setIsUploadingImage(false);
     }
-  }, [file, roomId, accessToken, member.nickname, clearFile]);
+  }, [file, roomId, accessToken, clearFile]);
 
   const handleSubmit = useCallback(() => {
     if (file) {

--- a/src/hooks/useRestDay.ts
+++ b/src/hooks/useRestDay.ts
@@ -1,4 +1,3 @@
-import { useAuth } from '@/contexts/AuthContext';
 import { api } from '@/lib/api';
 import { format } from 'date-fns';
 import { useState } from 'react';
@@ -10,7 +9,6 @@ today.setHours(0, 0, 0, 0);
 export const useRestDay = () => {
   const navigate = useNavigate();
 
-  const { member } = useAuth();
   const [showRestDialog, setShowRestDialog] = useState(false);
   const [restReason, setRestReason] = useState('');
   const [restStartDate, setRestStartDate] = useState<Date | undefined>(new Date());
@@ -68,14 +66,6 @@ export const useRestDay = () => {
       setRestReason('');
       setRestStartDate(new Date());
       setRestEndDate(new Date());
-
-      api.notifyAllRoomMembers({
-        title: `${member.nickname}님이 휴식일을 등록했어요!`,
-        body: `${fmRestStartDate} ~ ${fmRestEndDate}`,
-        type: "REST",
-      }).catch((notifyErr) => {
-        console.warn('휴식 알림 전송 실패', notifyErr);
-      });
 
       setShowRestSuccessDialog(true);
     } catch (err) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -282,20 +282,6 @@ class ApiClient {
     });
   }
 
-  async notifyAllRoomMembers(payload: { title: string, body: string, type: string }) {
-    return this.request(`/notifications/rooms`, {
-      method: "POST",
-      data: payload,
-    });
-  }
-
-  async notifyRoomMembers(roomId: number, payload: { title: string, body: string, type: string }) {
-    return this.request(`/notifications/rooms/${roomId}`, {
-      method: "POST",
-      data: payload,
-    });
-  }
-  
   // Penalty APIs
   async getPenaltyAccount(roomId: number) {
     return this.request(`/penalty/rooms/${roomId}/account`);

--- a/src/pages/WorkoutUploadPage.tsx
+++ b/src/pages/WorkoutUploadPage.tsx
@@ -226,20 +226,6 @@ export const WorkoutUploadPage = () => {
 
       const data = await api.uploadWorkout(workoutData, selectedImages) as WorkoutResponse;
 
-      // 날짜가 오늘인지 확인 (타임스탬프 비교)
-      const isTodayParams = today.getTime() === toDateOnly(workoutDate).getTime();
-
-      // 날짜에 따라 메시지 분기 처리
-      const dateText = isTodayParams ? "오늘" : format(workoutDate, 'yyyy-MM-dd');
-
-      api.notifyAllRoomMembers({
-        title: `${member.nickname}님이 ${dateText} 운동을 인증했어요!`,
-        body: `운동시간: ${duration}분`,
-        type: "WORKOUT",
-      }).catch((notifyErr) => {
-        console.warn('운동 업로드 알림 전송 실패', notifyErr);
-      });
-
       setTotalWorkoutDays(data.memberTotalWorkoutDays);
 
       const currentWorkoutRoomId = getCurrentWorkoutRoomId();


### PR DESCRIPTION
Closes #149

## Description

백엔드(BE-HCM #141 / PR #142)에서 운동 인증, 휴식일 등록, 채팅 메시지/이미지 전송 시 자동으로 푸시 알림을 발송하도록 변경됨에 따라, 프론트엔드가 별도로 호출하던 알림 트리거 로직을 제거합니다.

- `WorkoutUploadPage.tsx`: 운동 인증 성공 후 `api.notifyAllRoomMembers` 호출 제거
- `useRestDay.ts`: 휴식일 등록 성공 후 `api.notifyAllRoomMembers` 호출 제거, 더 이상 쓰이지 않는 `useAuth`/`member` 정리
- `ChatRoom.tsx`: 텍스트/이미지 메시지 전송 후 `api.notifyRoomMembers` 호출 제거 (2곳)
- `api.ts`: 더 이상 호출되지 않는 `notifyAllRoomMembers`, `notifyRoomMembers` 메서드 삭제

## Test plan

- [x] `npm run lint` 통과
- [x] `npm run build` 통과

## 배포 관련 유의사항

BE-HCM PR #142과 세트입니다. 알림 중복 발송 구간을 최소화하기 위해 백엔드 배포 직후 최대한 빠르게 배포해주세요.