### PR TITLE
주식 화면 수익 집계 오류 및 권한 가드·중복 코드 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sw?
 
 .env
+# TypeScript incremental build info (tsc -b)
+*.tsbuildinfo

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,9 +99,9 @@ const AppRoutes = () => (
       </ProtectedRoute>
     } />
     <Route path="/stock/portfolio" element={
-      <ProtectedRoute>
+      <RequireRole allowedRoles={['FAMILY', 'ADMIN']}>
         <StockPortfolioPage />
-      </ProtectedRoute>
+      </RequireRole>
     } />
     <Route path="/mypage" element={
       <ProtectedRoute>

--- a/src/components/stock/PeriodSegmentControl.tsx
+++ b/src/components/stock/PeriodSegmentControl.tsx
@@ -14,16 +14,11 @@ const PERIOD_OPTIONS: { value: PeriodType; label: string }[] = [
 interface PeriodSegmentControlProps {
   value: PeriodType;
   onChange: (value: PeriodType) => void;
-  dark?: boolean;
 }
 
-const PeriodSegmentControl: React.FC<PeriodSegmentControlProps> = ({ value, onChange, dark }) => {
-  const baseClass = dark
-    ? 'text-gray-400 hover:text-gray-200'
-    : 'text-gray-600 hover:text-gray-900';
-  const activeClass = dark
-    ? 'bg-gray-700 text-white'
-    : 'bg-gray-200 text-gray-900';
+const PeriodSegmentControl: React.FC<PeriodSegmentControlProps> = ({ value, onChange }) => {
+  const baseClass = 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200';
+  const activeClass = 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white';
 
   return (
     <div className="flex gap-1 p-1 rounded-lg min-h-[44px] overflow-x-auto">

--- a/src/components/stock/ProfitDetailSection.tsx
+++ b/src/components/stock/ProfitDetailSection.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import type { TradingProfitLoss } from '@/types';
+import type { DailyProfitGroup, StockProfitGroup } from '@/lib/stockProfit';
+import { formatCurrency, formatPercentage, getProfitLossColor, getInitials } from '@/lib/stockFormat';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { cn } from '@/lib/utils';
+import { STOCK_CARD_BG, STOCK_TEXT_MUTED, STOCK_ROW_BORDER } from '@/lib/stockTheme';
+
+export type ProfitMetric = 'sales' | 'fee' | 'tax';
+export type DetailViewMode = 'daily' | 'stock';
+
+const parseLocalDate = (value: string): Date => {
+  if (!value || typeof value !== 'string') return new Date(NaN);
+  const parts = value.split(/[-/T]/);
+  const y = parseInt(parts[0], 10);
+  const m = parseInt(parts[1], 10) || 1;
+  const d = parseInt(parts[2], 10) || 1;
+  if (isNaN(y) || isNaN(m) || isNaN(d)) return new Date(NaN);
+  return new Date(y, m - 1, d);
+};
+
+const formatDateSafe = (date: Date, formatStr: string, fallback: string): string => {
+  if (!date || isNaN(date.getTime())) return fallback;
+  try {
+    return format(date, formatStr, { locale: ko });
+  } catch {
+    return fallback;
+  }
+};
+
+/**
+ * 수수료·제세금은 지출이므로 음수로 표시한다. 판매수익만 부호를 그대로 쓰고 수익률을 함께 보여준다.
+ */
+const metricValue = {
+  sales: {
+    trade: (t: TradingProfitLoss) => t.profitLoss,
+    daily: (g: DailyProfitGroup) => g.profit,
+    stock: (s: StockProfitGroup) => s.profit,
+    showRate: true,
+  },
+  fee: {
+    trade: (t: TradingProfitLoss) => -t.fee,
+    daily: (g: DailyProfitGroup) => -g.fee,
+    stock: (s: StockProfitGroup) => -s.fee,
+    showRate: false,
+  },
+  tax: {
+    trade: (t: TradingProfitLoss) => -t.tax,
+    daily: (g: DailyProfitGroup) => -g.tax,
+    stock: (s: StockProfitGroup) => -s.tax,
+    showRate: false,
+  },
+} as const;
+
+interface ProfitDetailSectionProps {
+  metric: ProfitMetric;
+  total: number;
+  totalRate?: number | null;
+  dailyGroups: DailyProfitGroup[];
+  stockGroups: StockProfitGroup[];
+  viewMode: DetailViewMode;
+  onViewModeChange: (mode: DetailViewMode) => void;
+}
+
+const ProfitDetailSection: React.FC<ProfitDetailSectionProps> = ({
+  metric,
+  total,
+  totalRate,
+  dailyGroups,
+  stockGroups,
+  viewMode,
+  onViewModeChange,
+}) => {
+  const accessor = metricValue[metric];
+  const cardBg = STOCK_CARD_BG;
+  const textMuted = STOCK_TEXT_MUTED;
+  const rowBorder = STOCK_ROW_BORDER;
+
+  const handleDailyClick = () => onViewModeChange('daily');
+  const handleStockClick = () => onViewModeChange('stock');
+
+  const renderRow = (key: string, name: string, value: number, rate?: number | null) => (
+    <div
+      key={key}
+      className={cn('flex items-center justify-between p-3 rounded-lg min-h-[56px]', cardBg, rowBorder)}
+    >
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
+          {getInitials(name)}
+        </div>
+        <div className="min-w-0">
+          <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">{name}</div>
+          <div className={cn('text-sm', getProfitLossColor(value))}>
+            {formatCurrency(value)}
+            {rate != null && ` (${formatPercentage(rate)})`}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <p className={cn('text-xl font-bold', getProfitLossColor(total))}>
+          {formatCurrency(total)}
+          {accessor.showRate && totalRate != null && ` (${formatPercentage(totalRate)})`}
+        </p>
+        <div className="flex rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 shrink-0">
+          <button
+            type="button"
+            aria-pressed={viewMode === 'daily'}
+            className={cn(
+              'px-3 py-2 text-sm min-h-[40px]',
+              viewMode === 'daily' ? 'bg-gray-200 dark:bg-gray-700' : textMuted
+            )}
+            onClick={handleDailyClick}
+          >
+            일별
+          </button>
+          <button
+            type="button"
+            aria-pressed={viewMode === 'stock'}
+            className={cn(
+              'px-3 py-2 text-sm min-h-[40px]',
+              viewMode === 'stock' ? 'bg-gray-200 dark:bg-gray-700' : textMuted
+            )}
+            onClick={handleStockClick}
+          >
+            종목별 합계
+          </button>
+        </div>
+      </div>
+
+      {viewMode === 'daily' && (
+        <div className="space-y-4 overflow-y-auto max-h-[400px]">
+          {dailyGroups.map((group) => {
+            const dayValue = accessor.daily(group);
+            return (
+              <div key={group.date}>
+                <div className="text-sm font-medium mb-2">
+                  {formatDateSafe(parseLocalDate(group.date), 'M월 d일 (EEE)', group.date)} ·{' '}
+                  <span className={getProfitLossColor(dayValue)}>
+                    {formatCurrency(dayValue)}
+                    {accessor.showRate && ` (${formatPercentage(group.rate)})`}
+                  </span>
+                </div>
+                <div className="space-y-2 pl-2">
+                  {group.trades.map((trade, i) =>
+                    renderRow(
+                      `${trade.stockCode}-${trade.tradeType}-${i}`,
+                      trade.stockName,
+                      accessor.trade(trade),
+                      accessor.showRate ? trade.profitLossRate : null
+                    )
+                  )}
+                </div>
+              </div>
+            );
+          })}
+          {dailyGroups.length === 0 && (
+            <div className={cn('py-8 text-center', textMuted)}>거래 내역이 없습니다.</div>
+          )}
+        </div>
+      )}
+
+      {viewMode === 'stock' && (
+        <div className="space-y-2 overflow-y-auto max-h-[400px]">
+          {stockGroups.map((stock) =>
+            renderRow(
+              stock.code,
+              stock.name,
+              accessor.stock(stock),
+              accessor.showRate ? stock.rate : null
+            )
+          )}
+          {stockGroups.length === 0 && (
+            <div className={cn('py-8 text-center', textMuted)}>종목별 내역이 없습니다.</div>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ProfitDetailSection;

--- a/src/components/stock/StockAssetsTab.tsx
+++ b/src/components/stock/StockAssetsTab.tsx
@@ -16,6 +16,7 @@ import StockChart from '@/components/StockChart';
 import StockHoldingListItem from './StockHoldingListItem';
 import StockTradingHistoryDialog from './StockTradingHistoryDialog';
 import { cn } from '@/lib/utils';
+import { STOCK_CARD_BG, STOCK_TEXT_MUTED, STOCK_BORDER, STOCK_SEGMENT_ACTIVE } from '@/lib/stockTheme';
 
 const formatDateLocal = (date: Date) => {
   const y = date.getFullYear();
@@ -44,7 +45,6 @@ interface StockAssetsTabProps {
   onRefresh: () => void;
   loading: boolean;
   onNavigateToProfit: () => void;
-  dark?: boolean;
 }
 
 const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
@@ -52,7 +52,6 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
   onRefresh,
   loading,
   onNavigateToProfit,
-  dark,
 }) => {
   const isMobile = useIsMobile();
   const [viewMode, setViewMode] = useState<ViewMode>('marketValue');
@@ -97,8 +96,8 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
     });
   }, [portfolio.holdings, sortOption]);
 
-  const cardBg = dark ? 'bg-gray-800/50 border-gray-700' : 'bg-white border-gray-200';
-  const textMuted = dark ? 'text-gray-400' : 'text-gray-600';
+  const cardBg = STOCK_CARD_BG;
+  const textMuted = STOCK_TEXT_MUTED;
 
   return (
     <div className={cn('space-y-4 sm:space-y-6', isMobile && 'pb-6')}>
@@ -155,7 +154,6 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
       <StockChart
         holdings={portfolio.holdings}
         totalMarketValue={portfolio.totalMarketValue}
-        dark={dark}
       />
 
       {/* 주식 보유 목록 헤더 */}
@@ -175,7 +173,7 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
         <div
           className={cn(
             'inline-flex rounded-lg overflow-hidden border text-sm',
-            dark ? 'border-gray-600' : 'border-gray-200'
+            'border-gray-200 dark:border-gray-600'
           )}
         >
           <button
@@ -184,9 +182,7 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
             className={cn(
               'px-4 py-2 min-w-[70px] font-medium transition-colors',
               displayMode === 'currentPrice'
-                ? dark
-                  ? 'bg-gray-100 text-gray-900'
-                  : 'bg-gray-900 text-white'
+                ? STOCK_SEGMENT_ACTIVE
                 : textMuted
             )}
           >
@@ -198,9 +194,7 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
             className={cn(
               'px-4 py-2 min-w-[70px] font-medium transition-colors',
               displayMode === 'marketValue'
-                ? dark
-                  ? 'bg-gray-100 text-gray-900'
-                  : 'bg-gray-900 text-white'
+                ? STOCK_SEGMENT_ACTIVE
                 : textMuted
             )}
           >
@@ -220,7 +214,6 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
               holding={holding}
               displayMode={displayMode}
               isMobile={isMobile}
-              dark={dark}
               trades={(tradesSummary?.trades ?? []).filter((t) => t.stockCode === holding.stockCode)}
             />
           ))
@@ -228,9 +221,9 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
       </div>
 
       {/* 하단 요약 링크 영역 */}
-      <div className={cn('space-y-2 pt-4 border-t', dark ? 'border-gray-700' : 'border-gray-200')}>
+      <div className={cn('space-y-2 pt-4 border-t', STOCK_BORDER)}>
         <Button
-          variant={dark ? 'secondary' : 'default'}
+          variant="default"
           className="w-full min-h-[48px] justify-between"
           onClick={onNavigateToProfit}
         >
@@ -238,7 +231,7 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
           <ChevronRight className="h-5 w-5" />
         </Button>
         <Button
-          variant={dark ? 'secondary' : 'default'}
+          variant="default"
           className="w-full min-h-[48px] justify-between"
           onClick={() => setIsTradingHistoryOpen(true)}
         >
@@ -261,7 +254,6 @@ const StockAssetsTab: React.FC<StockAssetsTabProps> = ({
         open={isTradingHistoryOpen}
         onOpenChange={setIsTradingHistoryOpen}
         trades={tradesSummary?.trades ?? []}
-        dark={dark}
       />
     </div>
   );

--- a/src/components/stock/StockHoldingListItem.tsx
+++ b/src/components/stock/StockHoldingListItem.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ChevronUp, Check } from 'lucide-react';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
+import { STOCK_TEXT_MUTED, STOCK_BORDER, STOCK_SEGMENT_ACTIVE } from '@/lib/stockTheme';
 
 const formatCurrency = (amount: number) =>
   new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(amount);
@@ -49,7 +50,6 @@ interface StockHoldingListItemProps {
   holding: StockHolding;
   displayMode: DisplayMode;
   isMobile: boolean;
-  dark?: boolean;
   trades?: TradingProfitLoss[];
 }
 
@@ -57,14 +57,13 @@ const StockHoldingListItem: React.FC<StockHoldingListItemProps> = ({
   holding,
   displayMode,
   isMobile,
-  dark,
   trades = [],
 }) => {
   const [expanded, setExpanded] = useState(false);
   const [tradeSortOrder, setTradeSortOrder] = useState<'desc' | 'asc'>('desc'); // desc=최신순
-  const textMuted = dark ? 'text-gray-400' : 'text-gray-600';
-  const cardBg = dark ? 'bg-gray-800/50' : 'bg-white';
-  const borderColor = dark ? 'border-gray-700' : 'border-gray-200';
+  const textMuted = STOCK_TEXT_MUTED;
+  const cardBg = 'bg-white dark:bg-gray-800/50';
+  const borderColor = STOCK_BORDER;
 
   const tradesGrouped = useMemo(() => {
     const sorted = [...trades].sort((a, b) => {
@@ -145,9 +144,7 @@ const StockHoldingListItem: React.FC<StockHoldingListItemProps> = ({
               className={cn(
                 'px-2.5 py-1 min-w-[60px]',
                 tradeSortOrder === 'desc'
-                  ? dark
-                    ? 'bg-gray-100 text-gray-900'
-                    : 'bg-gray-900 text-white'
+                  ? STOCK_SEGMENT_ACTIVE
                   : textMuted
               )}
               onClick={() => setTradeSortOrder('desc')}
@@ -159,9 +156,7 @@ const StockHoldingListItem: React.FC<StockHoldingListItemProps> = ({
               className={cn(
                 'px-2.5 py-1 min-w-[60px]',
                 tradeSortOrder === 'asc'
-                  ? dark
-                    ? 'bg-gray-100 text-gray-900'
-                    : 'bg-gray-900 text-white'
+                  ? STOCK_SEGMENT_ACTIVE
                   : textMuted
               )}
               onClick={() => setTradeSortOrder('asc')}

--- a/src/components/stock/StockProfitTab.tsx
+++ b/src/components/stock/StockProfitTab.tsx
@@ -1,17 +1,16 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import {
-  TradingProfitLossSummary,
-  TradingProfitLossPeriod,
-  TradingProfitLoss,
-} from '@/types';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import type { TradingProfitLossSummary, TradingProfitLossPeriod } from '@/types';
+import { groupSellTradesByDate, groupSellTradesByStock } from '@/lib/stockProfit';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react';
 import { api } from '@/lib/api';
-import { useIsMobile } from '@/hooks/use-mobile';
 import { format, subDays, subWeeks, subMonths, subYears, startOfMonth, endOfMonth, startOfYear, endOfYear } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import PeriodSegmentControl, { PeriodType } from './PeriodSegmentControl';
+import ProfitDetailSection, { ProfitMetric, DetailViewMode } from './ProfitDetailSection';
+import { formatCurrency, formatPercentage, getProfitLossColor } from '@/lib/stockFormat';
 import { cn } from '@/lib/utils';
+import { STOCK_CARD_BG, STOCK_TEXT_MUTED } from '@/lib/stockTheme';
 
 const formatDateLocal = (date: Date) => {
   const y = date.getFullYear();
@@ -38,37 +37,19 @@ const formatDateSafe = (date: Date, formatStr: string, fallback: string): string
   }
 };
 
-const formatCurrency = (amount: number) =>
-  new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(amount);
-const formatPercentage = (rate: number) =>
-  `${rate >= 0 ? '+' : ''}${rate.toFixed(2)}%`;
+const PROFIT_TABS: ReadonlyArray<{ key: ProfitMetric; label: string }> = [
+  { key: 'sales', label: '판매수익' },
+  { key: 'fee', label: '수수료' },
+  { key: 'tax', label: '제세금' },
+];
 
-const getProfitLossColor = (amount: number) => {
-  if (amount > 0) return 'text-red-500 dark:text-red-400';
-  if (amount < 0) return 'text-blue-500 dark:text-blue-400';
-  return 'text-gray-400 dark:text-gray-500';
-};
-
-const getInitials = (stockName: string) => {
-  if (!stockName?.length) return '?';
-  return stockName.replace(/\s/g, '').slice(0, 2).toUpperCase();
-};
-
-type ProfitTypeTab = 'sales' | 'fee' | 'tax';
-type DetailViewMode = 'daily' | 'stock';
-
-interface StockProfitTabProps {
-  dark?: boolean;
-}
-
-const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
-  const isMobile = useIsMobile();
+const StockProfitTab = () => {
   const [summary, setSummary] = useState<TradingProfitLossSummary | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [periodType, setPeriodType] = useState<PeriodType>('MONTHLY');
   const [navOffset, setNavOffset] = useState(0); // 0=현재, 음수=과거
-  const [profitTypeTab, setProfitTypeTab] = useState<ProfitTypeTab>('sales');
+  const [profitTypeTab, setProfitTypeTab] = useState<ProfitMetric>('sales');
   const [detailViewMode, setDetailViewMode] = useState<DetailViewMode>('daily');
 
   const handlePeriodTypeChange = (type: PeriodType) => {
@@ -135,19 +116,25 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
 
   const canGoNext = navOffset < 0;
 
-  const fetchData = useCallback(async () => {
+  // 화살표를 연달아 누르면 무거운 조회가 중첩되고, 늦게 도착한 이전 응답이 최신 응답을
+  // 덮어쓸 수 있다. 요청마다 세대 번호를 붙여 마지막 요청의 결과만 반영한다.
+  const requestIdRef = useRef(0);
+
+  const fetchData = useCallback(async (): Promise<void> => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     setError(null);
     try {
-      const data = (await api.getTradingProfitLoss({
-        ...appliedPeriod,
-        periodType: appliedPeriod.periodType,
-      })) as TradingProfitLossSummary;
+      const data = await api.getTradingProfitLoss(appliedPeriod);
+      if (requestId !== requestIdRef.current) return;
       setSummary(data);
     } catch (err) {
+      if (requestId !== requestIdRef.current) return;
       setError(err instanceof Error ? err.message : '수익 분석을 불러오는데 실패했습니다.');
     } finally {
-      setLoading(false);
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
     }
   }, [appliedPeriod]);
 
@@ -185,45 +172,18 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
   const tax = summary?.totalTax ?? 0;
   const totalRealized = salesProfit - fee - tax;
 
-  const tradesByDate = useMemo(() => {
-    if (!summary?.trades?.length) return {};
-    const sellTrades = summary.trades.filter((t) => t.tradeType === 'SELL');
-    return sellTrades.reduce((acc, t) => {
-      if (!acc[t.tradeDate]) acc[t.tradeDate] = [];
-      acc[t.tradeDate].push(t);
-      return acc;
-    }, {} as Record<string, TradingProfitLoss[]>);
-  }, [summary?.trades]);
+  // 수수료·제세금은 지출이므로 상세 섹션에 음수로 넘긴다.
+  const metricTotals: Record<ProfitMetric, number> = {
+    sales: salesProfit,
+    fee: -fee,
+    tax: -tax,
+  };
 
-  const tradesByStock = useMemo(() => {
-    if (!summary?.trades?.length) return [];
-    const sellTrades = summary.trades.filter((t) => t.tradeType === 'SELL');
-    const map = new Map<
-      string,
-      { name: string; code: string; profit: number; rate: number; fee: number; tax: number; count: number }
-    >();
-    for (const t of sellTrades) {
-      const existing = map.get(t.stockCode);
-      if (existing) {
-        existing.profit += t.profitLoss;
-        existing.count += 1;
-      } else {
-        map.set(t.stockCode, {
-          name: t.stockName,
-          code: t.stockCode,
-          profit: t.profitLoss,
-          rate: t.profitLossRate,
-          fee: t.fee,
-          tax: t.tax,
-          count: 1,
-        });
-      }
-    }
-    return Array.from(map.values()).sort((a, b) => b.profit - a.profit);
-  }, [summary?.trades]);
+  const dailyGroups = useMemo(() => groupSellTradesByDate(summary?.trades), [summary?.trades]);
+  const tradesByStock = useMemo(() => groupSellTradesByStock(summary?.trades), [summary?.trades]);
 
-  const cardBg = dark ? 'bg-gray-800/50 border-gray-700' : 'bg-white border-gray-200';
-  const textMuted = dark ? 'text-gray-400' : 'text-gray-600';
+  const cardBg = STOCK_CARD_BG;
+  const textMuted = STOCK_TEXT_MUTED;
 
   if (loading && !summary) {
     return (
@@ -248,7 +208,7 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
   return (
     <div className="space-y-4 sm:space-y-6">
       {/* 기간 필터 */}
-      <PeriodSegmentControl value={periodType} onChange={handlePeriodTypeChange} dark={dark} />
+      <PeriodSegmentControl value={periodType} onChange={handlePeriodTypeChange} />
 
       {/* 실현수익 요약 */}
       <div className={cn('p-4 rounded-xl border', cardBg)}>
@@ -306,14 +266,11 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
 
       {/* 수익 유형 탭 */}
       <div className="flex border-b border-gray-200 dark:border-gray-700 min-h-[44px]">
-        {[
-          { key: 'sales' as const, label: '판매수익' },
-          { key: 'fee' as const, label: '수수료' },
-          { key: 'tax' as const, label: '제세금' },
-        ].map((tab) => (
+        {PROFIT_TABS.map((tab) => (
           <button
             key={tab.key}
             type="button"
+            aria-pressed={profitTypeTab === tab.key}
             onClick={() => setProfitTypeTab(tab.key)}
             className={cn(
               'flex-1 min-h-[44px] text-sm font-medium border-b-2 transition-colors',
@@ -327,357 +284,16 @@ const StockProfitTab: React.FC<StockProfitTabProps> = ({ dark }) => {
         ))}
       </div>
 
-      {/* 판매수익 상세 */}
-      {profitTypeTab === 'sales' && (
-        <>
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-            <p className={cn('text-xl font-bold', getProfitLossColor(salesProfit))}>
-              {formatCurrency(salesProfit)}
-              {summary?.totalProfitLossRate != null && ` (${formatPercentage(summary.totalProfitLossRate)})`}
-            </p>
-            <div className="flex rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 shrink-0">
-              <button
-                type="button"
-                className={cn(
-                  'px-3 py-2 text-sm min-h-[40px]',
-                  detailViewMode === 'daily' ? 'bg-gray-200 dark:bg-gray-700' : textMuted
-                )}
-                onClick={() => setDetailViewMode('daily')}
-              >
-                일별
-              </button>
-              <button
-                type="button"
-                className={cn(
-                  'px-3 py-2 text-sm min-h-[40px]',
-                  detailViewMode === 'stock' ? 'bg-gray-200 dark:bg-gray-700' : textMuted
-                )}
-                onClick={() => setDetailViewMode('stock')}
-              >
-                종목별 합계
-              </button>
-            </div>
-          </div>
-
-          {detailViewMode === 'daily' && (
-            <div className="space-y-4 overflow-y-auto max-h-[400px]">
-              {Object.entries(tradesByDate)
-                .sort(([a], [b]) => b.localeCompare(a))
-                .map(([dateStr, trades]) => {
-                  const date = parseLocalDate(dateStr);
-                  const dayProfit = trades.reduce((s, t) => s + t.profitLoss, 0);
-                  const dayRate = trades[0]?.profitLossRate ?? 0;
-                  return (
-                    <div key={dateStr}>
-                      <div className="text-sm font-medium mb-2">
-                        {formatDateSafe(date, 'M월 d일 (EEE)', dateStr)} ·{' '}
-                        <span className={getProfitLossColor(dayProfit)}>
-                          {formatCurrency(dayProfit)} ({formatPercentage(dayRate)})
-                        </span>
-                      </div>
-                      <div className="space-y-2 pl-2">
-                        {trades.map((t, i) => (
-                          <div
-                            key={`${t.stockCode}-${t.tradeType}-${i}`}
-                            className={cn(
-                              'flex items-center justify-between p-3 rounded-lg min-h-[56px]',
-                              cardBg,
-                              dark ? 'border border-gray-700' : 'border border-gray-200'
-                            )}
-                          >
-                            <div className="flex items-center gap-3 min-w-0">
-                              <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
-                                {getInitials(t.stockName)}
-                              </div>
-                              <div className="min-w-0">
-                                <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
-                                  {t.stockName}
-                                </div>
-                                <div className={cn('text-sm', getProfitLossColor(t.profitLoss))}>
-                                  {formatCurrency(t.profitLoss)} ({formatPercentage(t.profitLossRate)})
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  );
-                })}
-              {Object.keys(tradesByDate).length === 0 && (
-                <div className={cn('py-8 text-center', textMuted)}>거래 내역이 없습니다.</div>
-              )}
-            </div>
-          )}
-
-          {detailViewMode === 'stock' && (
-            <div className="space-y-2 overflow-y-auto max-h-[400px]">
-              {tradesByStock.map((s) => (
-                <div
-                  key={s.code}
-                  className={cn(
-                    'flex items-center justify-between p-4 rounded-lg min-h-[56px]',
-                    cardBg,
-                    dark ? 'border border-gray-700' : 'border border-gray-200'
-                  )}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
-                      {getInitials(s.name)}
-                    </div>
-                    <div className="min-w-0">
-                      <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
-                        {s.name}
-                      </div>
-                      <div className={cn('text-sm', getProfitLossColor(s.profit))}>
-                        {formatCurrency(s.profit)}
-                        {s.count === 1 && ` (${formatPercentage(s.rate)})`}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-              {tradesByStock.length === 0 && (
-                <div className={cn('py-8 text-center', textMuted)}>종목별 내역이 없습니다.</div>
-              )}
-            </div>
-          )}
-        </>
-      )}
-
-      {/* 수수료 상세 */}
-      {profitTypeTab === 'fee' && (
-        <>
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-            <p className={cn('text-xl font-bold', getProfitLossColor(-fee))}>
-              -{formatCurrency(fee)}
-            </p>
-            <div className="flex rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 shrink-0">
-              <button
-                type="button"
-                className={cn(
-                  'px-3 py-2 text-sm min-h-[40px]',
-                  detailViewMode === 'daily' ? 'bg-gray-200 dark:bg-gray-700' : textMuted
-                )}
-                onClick={() => setDetailViewMode('daily')}
-              >
-                일별
-              </button>
-              <button
-                type="button"
-                className={cn(
-                  'px-3 py-2 text-sm min-h-[40px]',
-                  detailViewMode === 'stock' ? 'bg-gray-200 dark:bg-gray-700' : textMuted
-                )}
-                onClick={() => setDetailViewMode('stock')}
-              >
-                종목별 합계
-              </button>
-            </div>
-          </div>
-
-          {detailViewMode === 'daily' && (
-            <div className="space-y-4 overflow-y-auto max-h-[400px]">
-              {Object.entries(tradesByDate)
-                .sort(([a], [b]) => b.localeCompare(a))
-                .map(([dateStr, trades]) => {
-                  const date = parseLocalDate(dateStr);
-                  const dayFee = trades.reduce((s, t) => s + t.fee, 0);
-                  return (
-                    <div key={dateStr}>
-                      <div className="text-sm font-medium mb-2">
-                        {formatDateSafe(date, 'M월 d일 (EEE)', dateStr)} ·{' '}
-                        <span className={getProfitLossColor(-dayFee)}>
-                          -{formatCurrency(dayFee)}
-                        </span>
-                      </div>
-                      <div className="space-y-2 pl-2">
-                        {trades.map((t, i) => (
-                          <div
-                            key={`${t.stockCode}-${t.tradeType}-${i}`}
-                            className={cn(
-                              'flex items-center justify-between p-3 rounded-lg min-h-[56px]',
-                              cardBg,
-                              dark ? 'border border-gray-700' : 'border border-gray-200'
-                            )}
-                          >
-                            <div className="flex items-center gap-3 min-w-0">
-                              <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
-                                {getInitials(t.stockName)}
-                              </div>
-                              <div className="min-w-0">
-                                <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
-                                  {t.stockName}
-                                </div>
-                                <div className={cn('text-sm', getProfitLossColor(-t.fee))}>
-                                  -{formatCurrency(t.fee)}
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  );
-                })}
-              {Object.keys(tradesByDate).length === 0 && (
-                <div className={cn('py-8 text-center', textMuted)}>거래 내역이 없습니다.</div>
-              )}
-            </div>
-          )}
-
-          {detailViewMode === 'stock' && (
-            <div className="space-y-2 overflow-y-auto max-h-[400px]">
-              {tradesByStock.map((s) => (
-                <div
-                  key={s.code}
-                  className={cn(
-                    'flex items-center justify-between p-4 rounded-lg min-h-[56px]',
-                    cardBg,
-                    dark ? 'border border-gray-700' : 'border border-gray-200'
-                  )}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
-                      {getInitials(s.name)}
-                    </div>
-                    <div className="min-w-0">
-                      <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
-                        {s.name}
-                      </div>
-                      <div className={cn('text-sm', getProfitLossColor(-s.fee))}>
-                        -{formatCurrency(s.fee)}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-              {tradesByStock.length === 0 && (
-                <div className={cn('py-8 text-center', textMuted)}>종목별 내역이 없습니다.</div>
-              )}
-            </div>
-          )}
-        </>
-      )}
-
-      {/* 제세금 상세 */}
-      {profitTypeTab === 'tax' && (
-        <>
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-            <p className={cn('text-xl font-bold', getProfitLossColor(-tax))}>
-              -{formatCurrency(tax)}
-            </p>
-            <div className="flex rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 shrink-0">
-              <button
-                type="button"
-                className={cn(
-                  'px-3 py-2 text-sm min-h-[40px]',
-                  detailViewMode === 'daily' ? 'bg-gray-200 dark:bg-gray-700' : textMuted
-                )}
-                onClick={() => setDetailViewMode('daily')}
-              >
-                일별
-              </button>
-              <button
-                type="button"
-                className={cn(
-                  'px-3 py-2 text-sm min-h-[40px]',
-                  detailViewMode === 'stock' ? 'bg-gray-200 dark:bg-gray-700' : textMuted
-                )}
-                onClick={() => setDetailViewMode('stock')}
-              >
-                종목별 합계
-              </button>
-            </div>
-          </div>
-
-          {detailViewMode === 'daily' && (
-            <div className="space-y-4 overflow-y-auto max-h-[400px]">
-              {Object.entries(tradesByDate)
-                .sort(([a], [b]) => b.localeCompare(a))
-                .map(([dateStr, trades]) => {
-                  const date = parseLocalDate(dateStr);
-                  const dayTax = trades.reduce((s, t) => s + t.tax, 0);
-                  return (
-                    <div key={dateStr}>
-                      <div className="text-sm font-medium mb-2">
-                        {formatDateSafe(date, 'M월 d일 (EEE)', dateStr)} ·{' '}
-                        <span className={getProfitLossColor(-dayTax)}>
-                          -{formatCurrency(dayTax)}
-                        </span>
-                      </div>
-                      <div className="space-y-2 pl-2">
-                        {trades.map((t, i) => (
-                          <div
-                            key={`${t.stockCode}-${t.tradeType}-${i}`}
-                            className={cn(
-                              'flex items-center justify-between p-3 rounded-lg min-h-[56px]',
-                              cardBg,
-                              dark ? 'border border-gray-700' : 'border border-gray-200'
-                            )}
-                          >
-                            <div className="flex items-center gap-3 min-w-0">
-                              <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
-                                {getInitials(t.stockName)}
-                              </div>
-                              <div className="min-w-0">
-                                <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
-                                  {t.stockName}
-                                </div>
-                                <div className={cn('text-sm', getProfitLossColor(-t.tax))}>
-                                  -{formatCurrency(t.tax)}
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  );
-                })}
-              {Object.keys(tradesByDate).length === 0 && (
-                <div className={cn('py-8 text-center', textMuted)}>거래 내역이 없습니다.</div>
-              )}
-            </div>
-          )}
-
-          {detailViewMode === 'stock' && (
-            <div className="space-y-2 overflow-y-auto max-h-[400px]">
-              {tradesByStock.map((s) => (
-                <div
-                  key={s.code}
-                  className={cn(
-                    'flex items-center justify-between p-4 rounded-lg min-h-[56px]',
-                    cardBg,
-                    dark ? 'border border-gray-700' : 'border border-gray-200'
-                  )}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <div className="w-9 h-9 rounded-full bg-gray-600 flex items-center justify-center text-xs font-semibold text-white shrink-0">
-                      {getInitials(s.name)}
-                    </div>
-                    <div className="min-w-0">
-                      <div className="font-medium text-gray-900 dark:text-gray-100 break-words leading-snug">
-                        {s.name}
-                      </div>
-                      <div className={cn('text-sm', getProfitLossColor(-s.tax))}>
-                        -{formatCurrency(s.tax)}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-              {tradesByStock.length === 0 && (
-                <div className={cn('py-8 text-center', textMuted)}>종목별 내역이 없습니다.</div>
-              )}
-            </div>
-          )}
-        </>
-      )}            
-
-      {/* {profitTypeTab !== 'sales' && (
-        <div className={cn('py-12 text-center', textMuted)}>데이터가 없습니다.</div>
-      )} */}
+      {/* 선택된 유형의 상세 내역 — 판매수익/수수료/제세금이 동일한 레이아웃을 공유한다. */}
+      <ProfitDetailSection
+        metric={profitTypeTab}
+        total={metricTotals[profitTypeTab]}
+        totalRate={summary?.totalProfitLossRate}
+        dailyGroups={dailyGroups}
+        stockGroups={tradesByStock}
+        viewMode={detailViewMode}
+        onViewModeChange={setDetailViewMode}
+      />
 
       <Button
         variant="outline"

--- a/src/components/stock/StockTradingHistoryDialog.tsx
+++ b/src/components/stock/StockTradingHistoryDialog.tsx
@@ -7,12 +7,12 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
+import { STOCK_CARD_BG, STOCK_TEXT_MUTED, STOCK_TEXT_PRIMARY } from '@/lib/stockTheme';
 
 interface StockTradingHistoryDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   trades: TradingProfitLoss[];
-  dark?: boolean;
 }
 
 const formatDateToMD = (dateString: string): string => {
@@ -34,7 +34,6 @@ const StockTradingHistoryDialog: React.FC<StockTradingHistoryDialogProps> = ({
   open,
   onOpenChange,
   trades,
-  dark,
 }) => {
   const groupedTrades = useMemo(() => {
     if (!trades.length) return [];
@@ -68,16 +67,16 @@ const StockTradingHistoryDialog: React.FC<StockTradingHistoryDialogProps> = ({
     return grouped;
   }, [trades]);
 
-  const cardBg = dark ? 'bg-gray-800/50 border-gray-700' : 'bg-white border-gray-200';
-  const textMuted = dark ? 'text-gray-400' : 'text-gray-600';
-  const textPrimary = dark ? 'text-gray-100' : 'text-gray-900';
+  const cardBg = STOCK_CARD_BG;
+  const textMuted = STOCK_TEXT_MUTED;
+  const textPrimary = STOCK_TEXT_PRIMARY;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className={cn(
           'max-w-md w-full max-h-[90vh] overflow-hidden flex flex-col',
-          dark && 'bg-gray-900 border-gray-700'
+          'dark:bg-gray-900 dark:border-gray-700'
         )}
       >
         <DialogHeader>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,9 @@ import {
   PenaltyPayment,
   PenaltyRecord,
   SchedulePenaltyChangeRequest,
+  StockPortfolio,
+  TradingProfitLossPeriod,
+  TradingProfitLossSummary,
   WorkoutFeedItem,
   WorkoutRoom,
   WorkoutRoomDetail,
@@ -263,12 +266,16 @@ class ApiClient {
   }
 
   // Stock APIs
-  async getStockPortfolio() {
-    return this.request("/stock/portfolio");
+  async getStockPortfolio(config: AxiosRequestConfig = {}): Promise<StockPortfolio> {
+    return this.request<StockPortfolio>("/stock/portfolio", config);
   }
 
-  async getTradingProfitLoss(period: { startDate: string; endDate: string; periodType: string }) {
-    return this.request("/stock/trading-profit-loss", {
+  async getTradingProfitLoss(
+    period: TradingProfitLossPeriod,
+    config: AxiosRequestConfig = {}
+  ): Promise<TradingProfitLossSummary> {
+    return this.request<TradingProfitLossSummary>("/stock/trading-profit-loss", {
+      ...config,
       method: "POST",
       data: period,
     });

--- a/src/lib/stockFormat.ts
+++ b/src/lib/stockFormat.ts
@@ -1,0 +1,17 @@
+export const formatCurrency = (amount: number): string =>
+  new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(amount);
+
+export const formatPercentage = (rate: number): string =>
+  `${rate >= 0 ? '+' : ''}${rate.toFixed(2)}%`;
+
+/** 국내 증시 관례에 따라 이익은 빨강, 손실은 파랑으로 표시한다. */
+export const getProfitLossColor = (amount: number): string => {
+  if (amount > 0) return 'text-red-500 dark:text-red-400';
+  if (amount < 0) return 'text-blue-500 dark:text-blue-400';
+  return 'text-gray-400 dark:text-gray-500';
+};
+
+export const getInitials = (stockName: string): string => {
+  if (!stockName?.length) return '?';
+  return stockName.replace(/\s/g, '').slice(0, 2).toUpperCase();
+};

--- a/src/lib/stockProfit.ts
+++ b/src/lib/stockProfit.ts
@@ -1,0 +1,100 @@
+import type { TradingProfitLoss } from '@/types';
+
+/**
+ * 매도 거래의 취득원가. 한국투자증권 응답에서 매도금액(amount)과 실현손익(profitLoss)의
+ * 차이가 곧 매입금액이므로, 수익률을 다시 집계할 때는 이 값을 분모로 써야 한다.
+ */
+const costBasisOf = (trade: TradingProfitLoss): number => trade.amount - trade.profitLoss;
+
+/**
+ * 실현손익 합계와 취득원가 합계로 수익률(%)을 계산한다.
+ * 개별 거래의 수익률을 단순 평균하거나 첫 거래의 수익률을 대표값으로 쓰면 안 된다.
+ */
+export const computeProfitRate = (totalProfit: number, totalCostBasis: number): number => {
+  if (!totalCostBasis) return 0;
+  return (totalProfit / totalCostBasis) * 100;
+};
+
+export interface DailyProfitGroup {
+  date: string;
+  trades: TradingProfitLoss[];
+  profit: number;
+  rate: number;
+  fee: number;
+  tax: number;
+}
+
+/** 매도 거래만 거래일별로 묶고, 각 날짜의 손익·수익률·수수료·세금 합계를 낸다. 최신 날짜순. */
+export const groupSellTradesByDate = (trades: TradingProfitLoss[] = []): DailyProfitGroup[] => {
+  const buckets = new Map<string, TradingProfitLoss[]>();
+
+  for (const trade of trades) {
+    if (trade.tradeType !== 'SELL') continue;
+    const bucket = buckets.get(trade.tradeDate);
+    if (bucket) {
+      bucket.push(trade);
+    } else {
+      buckets.set(trade.tradeDate, [trade]);
+    }
+  }
+
+  return Array.from(buckets.entries())
+    .map(([date, dateTrades]) => {
+      const profit = dateTrades.reduce((sum, t) => sum + t.profitLoss, 0);
+      const costBasis = dateTrades.reduce((sum, t) => sum + costBasisOf(t), 0);
+      return {
+        date,
+        trades: dateTrades,
+        profit,
+        rate: computeProfitRate(profit, costBasis),
+        fee: dateTrades.reduce((sum, t) => sum + t.fee, 0),
+        tax: dateTrades.reduce((sum, t) => sum + t.tax, 0),
+      };
+    })
+    .sort((a, b) => b.date.localeCompare(a.date));
+};
+
+export interface StockProfitGroup {
+  code: string;
+  name: string;
+  profit: number;
+  rate: number;
+  fee: number;
+  tax: number;
+  count: number;
+}
+
+/** 매도 거래만 종목별로 합산한다. 손익·수수료·세금 모두 누적하고 수익률은 취득원가 기준으로 재계산한다. */
+export const groupSellTradesByStock = (trades: TradingProfitLoss[] = []): StockProfitGroup[] => {
+  const buckets = new Map<string, StockProfitGroup & { costBasis: number }>();
+
+  for (const trade of trades) {
+    if (trade.tradeType !== 'SELL') continue;
+    const existing = buckets.get(trade.stockCode);
+    if (existing) {
+      existing.profit += trade.profitLoss;
+      existing.fee += trade.fee;
+      existing.tax += trade.tax;
+      existing.costBasis += costBasisOf(trade);
+      existing.count += 1;
+    } else {
+      buckets.set(trade.stockCode, {
+        code: trade.stockCode,
+        name: trade.stockName,
+        profit: trade.profitLoss,
+        rate: 0,
+        fee: trade.fee,
+        tax: trade.tax,
+        costBasis: costBasisOf(trade),
+        count: 1,
+      });
+    }
+  }
+
+  return Array.from(buckets.values())
+    .map(({ costBasis, ...group }) => ({
+      ...group,
+      rate: computeProfitRate(group.profit, costBasis),
+    }))
+    .sort((a, b) => b.profit - a.profit);
+};

--- a/src/lib/stockTheme.ts
+++ b/src/lib/stockTheme.ts
@@ -1,0 +1,14 @@
+/**
+ * 주식 화면에서 공유하는 Tailwind 클래스 토큰.
+ * 이전에는 각 컴포넌트가 `dark` boolean prop 을 받아 JS 삼항으로 클래스를 골랐지만,
+ * 실제로는 항상 false 로 내려와 다크 스타일이 죽어 있었다. `dark:` 변형으로 통일해
+ * 앱 전역 테마 설정을 그대로 따르게 한다.
+ */
+export const STOCK_CARD_BG = 'bg-white border-gray-200 dark:bg-gray-800/50 dark:border-gray-700';
+export const STOCK_TEXT_MUTED = 'text-gray-600 dark:text-gray-400';
+export const STOCK_TEXT_PRIMARY = 'text-gray-900 dark:text-gray-100';
+export const STOCK_BORDER = 'border-gray-200 dark:border-gray-700';
+export const STOCK_ROW_BORDER = 'border border-gray-200 dark:border-gray-700';
+
+/** 선택된 세그먼트 버튼(현재가/평가금, 최신순/오래된순 등)의 반전 배경. */
+export const STOCK_SEGMENT_ACTIVE = 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900';

--- a/src/pages/StockPortfolioPage.tsx
+++ b/src/pages/StockPortfolioPage.tsx
@@ -1,160 +1,136 @@
-import React, { useState, useEffect } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
-import { StockPortfolio } from '@/types';
+import React, { useState, useEffect, useCallback } from 'react';
+import type { StockPortfolio } from '@/types';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { RefreshCw } from 'lucide-react';
 import { api } from '@/lib/api';
-import { useIsMobile } from '@/hooks/use-mobile';
 import { Layout } from '@/components/layout/Layout';
 import StockAssetsTab from '@/components/stock/StockAssetsTab';
 import StockProfitTab from '@/components/stock/StockProfitTab';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { toast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 
+type StockTab = 'assets' | 'profit';
+
+const TAB_TRIGGER_CLASS = cn(
+  'rounded-none border-b-2 min-h-[56px] data-[state=inactive]:text-gray-500',
+  'data-[state=active]:border-red-500 data-[state=active]:text-gray-900 data-[state=active]:bg-transparent',
+  'data-[state=inactive]:border-transparent'
+);
+
 const StockPortfolioPage = () => {
-  const { member } = useAuth();
-  const isMobile = useIsMobile();
   const [portfolio, setPortfolio] = useState<StockPortfolio | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<'assets' | 'profit'>('assets');
-  const darkMode = false;
+  const [activeTab, setActiveTab] = useState<StockTab>('assets');
 
-  const fetchPortfolio = async () => {
+  const fetchPortfolio = useCallback(async (): Promise<void> => {
     setLoading(true);
     setError(null);
     try {
-      const data = (await api.getStockPortfolio()) as StockPortfolio;
+      const data = await api.getStockPortfolio();
       setPortfolio(data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : '주식 현황을 불러오는데 실패했습니다.');
+      const message = err instanceof Error ? err.message : '주식 현황을 불러오는데 실패했습니다.';
+      setError(message);
+      // 이미 표시 중인 데이터가 있으면 화면을 갈아끼우지 않고 토스트로만 알린다.
+      // (에러를 조용히 삼키면 사용자가 새로고침이 성공한 것으로 오해한다)
+      setPortfolio((current) => {
+        if (current) {
+          toast({ title: '새로고침 실패', description: message, variant: 'destructive' });
+        }
+        return current;
+      });
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchPortfolio();
-  }, []);
+  }, [fetchPortfolio]);
 
-  if (member?.role !== 'FAMILY' && member?.role !== 'ADMIN') {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <Card className="w-96">
-          <CardHeader>
-            <CardTitle className="text-center text-red-500">접근 권한 없음</CardTitle>
-            <CardDescription className="text-center text-gray-600">
-              주식 현황 조회 서비스는 FAMILY 또는 ADMIN 권한이 필요한 서비스입니다.
-            </CardDescription>
-          </CardHeader>
-        </Card>
-      </div>
-    );
-  }
+  const handleNavigateToProfit = () => setActiveTab('profit');
+  const handleTabChange = (value: string) => setActiveTab(value as StockTab);
 
-  if (loading && !portfolio) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="flex flex-col items-center space-y-4">
+  const renderBody = () => {
+    if (loading && !portfolio) {
+      return (
+        <div className="flex flex-col items-center justify-center py-16 space-y-4">
           <RefreshCw className="h-8 w-8 animate-spin text-blue-600" />
           <p className="text-gray-600">주식 현황을 불러오는 중...</p>
         </div>
-      </div>
-    );
-  }
+      );
+    }
 
-  if (error && !portfolio) {
+    if (error && !portfolio) {
+      return (
+        <div className="flex items-center justify-center py-16">
+          <Card className="w-full max-w-sm">
+            <CardHeader>
+              <CardTitle className="text-center text-red-500">오류 발생</CardTitle>
+              <CardDescription className="text-center text-gray-600">{error}</CardDescription>
+            </CardHeader>
+            <div className="p-4">
+              <Button onClick={fetchPortfolio} className="w-full" disabled={loading}>
+                다시 시도
+              </Button>
+            </div>
+          </Card>
+        </div>
+      );
+    }
+
+    if (!portfolio) {
+      return (
+        <div className="flex items-center justify-center py-16">
+          <Card className="w-full max-w-sm">
+            <CardHeader>
+              <CardTitle className="text-center">데이터 없음</CardTitle>
+              <CardDescription className="text-center text-gray-600">
+                주식 현황 데이터가 없습니다.
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </div>
+      );
+    }
+
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <Card className="w-96">
-          <CardHeader>
-            <CardTitle className="text-center text-red-500">오류 발생</CardTitle>
-            <CardDescription className="text-center text-gray-600">{error}</CardDescription>
-          </CardHeader>
-          <div className="p-4">
-            <Button onClick={fetchPortfolio} className="w-full">
-              다시 시도
-            </Button>
-          </div>
-        </Card>
-      </div>
-    );
-  }
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
+        <div className="sticky top-0 z-10 bg-gray-50 border-b border-gray-200">
+          <TabsList className="w-full h-14 bg-transparent p-0 gap-0 rounded-none border-0 grid grid-cols-2">
+            <TabsTrigger value="assets" className={TAB_TRIGGER_CLASS}>
+              자산
+            </TabsTrigger>
+            <TabsTrigger value="profit" className={TAB_TRIGGER_CLASS}>
+              수익분석
+            </TabsTrigger>
+          </TabsList>
+        </div>
 
-  if (!portfolio) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <Card className="w-96">
-          <CardHeader>
-            <CardTitle className="text-center">데이터 없음</CardTitle>
-            <CardDescription className="text-center text-gray-600">
-              주식 현황 데이터가 없습니다.
-            </CardDescription>
-          </CardHeader>
-        </Card>
-      </div>
+        <div className="px-4 pt-4">
+          <TabsContent value="assets" className="mt-0">
+            <StockAssetsTab
+              portfolio={portfolio}
+              onRefresh={fetchPortfolio}
+              loading={loading}
+              onNavigateToProfit={handleNavigateToProfit}
+            />
+          </TabsContent>
+          <TabsContent value="profit" className="mt-0">
+            <StockProfitTab />
+          </TabsContent>
+        </div>
+      </Tabs>
     );
-  }
-
-  const pageBg = darkMode ? 'bg-gray-950' : 'bg-gray-50';
+  };
 
   return (
     <Layout>
-      <div className={cn('min-h-screen min-h-[100dvh] overflow-x-hidden', pageBg, 'pb-safe-bottom')}>
-        <div className="max-w-2xl mx-auto w-full overflow-x-hidden min-h-0">
-          {/* 상단 탭: 자산 | 수익분석 */}
-          <Tabs
-            value={activeTab}
-            onValueChange={(v) => setActiveTab(v as 'assets' | 'profit')}
-            className="w-full"
-          >
-            <div className="sticky top-0 z-10 bg-gray-50 border-b border-gray-200">
-              <TabsList
-                className={cn(
-                  'w-full h-14 bg-transparent p-0 gap-0 rounded-none border-0',
-                  'grid grid-cols-2'
-                )}
-              >
-                <TabsTrigger
-                  value="assets"
-                  className={cn(
-                    'rounded-none border-b-2 min-h-[56px] data-[state=inactive]:text-gray-500',
-                    'data-[state=active]:border-red-500 data-[state=active]:text-gray-900 data-[state=active]:bg-transparent',
-                    'data-[state=inactive]:border-transparent'
-                  )}
-                >
-                  자산
-                </TabsTrigger>
-                <TabsTrigger
-                  value="profit"
-                  className={cn(
-                    'rounded-none border-b-2 min-h-[56px] data-[state=inactive]:text-gray-500',
-                    'data-[state=active]:border-red-500 data-[state=active]:text-gray-900 data-[state=active]:bg-transparent',
-                    'data-[state=inactive]:border-transparent'
-                  )}
-                >
-                  수익분석
-                </TabsTrigger>
-              </TabsList>
-            </div>
-
-            <div className="px-4 pt-4">
-              <TabsContent value="assets" className="mt-0">
-                <StockAssetsTab
-                  portfolio={portfolio}
-                  onRefresh={fetchPortfolio}
-                  loading={loading}
-                  onNavigateToProfit={() => setActiveTab('profit')}
-                  dark={darkMode}
-                />
-              </TabsContent>
-              <TabsContent value="profit" className="mt-0">
-                <StockProfitTab dark={darkMode} />
-              </TabsContent>
-            </div>
-          </Tabs>
-        </div>
+      <div className="min-h-screen min-h-[100dvh] overflow-x-hidden bg-gray-50 pb-safe-bottom">
+        <div className="max-w-2xl mx-auto w-full overflow-x-hidden min-h-0">{renderBody()}</div>
       </div>
     </Layout>
   );


### PR DESCRIPTION
Closes #151

## Description

주식 화면의 수익 집계 오류를 수정하고, 권한 가드와 중복 코드를 정리했습니다.

### 1. 수익 분석 집계 오류 (사용자에게 틀린 금액이 표시되던 문제)

**종목별 수수료·제세금 합계**: `profit` 만 누적하고 `fee`·`tax`·`rate` 는 첫 거래 값을 그대로 두고 있어, 같은 종목을 여러 번 매도하면 실제보다 적은 금액이 표시됐습니다. 전부 누적하도록 수정했습니다.

**일별 수익률**: `trades[0]?.profitLossRate` 로 그날 첫 거래의 수익률을 하루 전체 수익률로 표시하고 있었습니다. 취득원가(`amount - profitLoss`) 합계 기준으로 재계산합니다.

집계 로직은 `src/lib/stockProfit.ts` 순수 함수로 분리해 테스트 가능한 형태로 만들었습니다.

### 2. 권한 가드

페이지 내부의 수동 권한 체크를 제거하고 라우트를 `RequireRole allowedRoles={['FAMILY','ADMIN']}` 로 전환했습니다. 이로써:

- 인증 복원 중 "접근 권한 없음" 이 잠깐 노출되던 문제 해소 (`loading` 처리)
- 권한 없는 사용자가 API 를 한 번 호출하던 문제 해소
- 기존 `RequireRole` 패턴과 일관성 확보

백엔드에서도 `/api/stock/**` 에 동일 권한을 걸었습니다 (BellWin98/BE-HCM#144).

### 3. 구조 정리

- **`Layout` 래핑**: 조기 반환 4개가 모두 `Layout` 밖에 있어 로딩·에러 상태에서 네비게이션이 사라지던 문제 수정
- **새로고침 실패 알림**: `error && !portfolio` 조건 탓에 조용히 무시되던 에러를 토스트로 표시
- **죽은 다크모드 코드 제거**: 항상 `false` 이던 `dark` prop 을 6개 컴포넌트에서 걷어내고 Tailwind `dark:` 클래스로 통일 (`stockTheme.ts` 토큰)
- **3중 중복 제거**: 판매수익/수수료/제세금 탭의 거의 동일한 약 350줄을 `ProfitDetailSection` 하나로 통합
- **race condition**: 기간 이동 화살표 연타 시 늦게 도착한 이전 응답이 최신 응답을 덮어쓰지 않도록 요청 세대 번호 도입
- **타입 안전성**: API 클라이언트에 제네릭을 적용해 `as` 캐스팅 제거

전체적으로 **579줄 삭제 / 171줄 추가**입니다.

## 검증

- `npx tsc -p tsconfig.app.json --noEmit` — `src` 전체 에러 없음
- `npm run lint` — 클린
- `npm run build` — 성공

### 주의: 타입 검사 명령

`tsconfig.json` 이 `"files": []` + project references 구조라 **`tsc -p tsconfig.json` 은 아무 파일도 검사하지 않고 통과합니다.** 실제로 이 함정 때문에 미정의 변수 참조를 한 번 놓쳤습니다. 올바른 명령은 다음과 같습니다:

```bash
npx tsc -b                              # project reference 를 따라감
npx tsc -p tsconfig.app.json --noEmit   # src 직접 검사
```

`tsc -b` 산출물인 `*.tsbuildinfo` 를 `.gitignore` 에 추가했습니다.

## 관련

백엔드 대응 PR: BellWin98/BE-HCM#144
